### PR TITLE
Handle HTTP status code 500

### DIFF
--- a/collective/quickupload/browser/static/fileuploader.js
+++ b/collective/quickupload/browser/static/fileuploader.js
@@ -842,6 +842,8 @@ qq.UploadHandlerXhr.prototype = {
 
                     self._options.onComplete(id, name, response);
 
+                } else if (xhr.status == 500){
+                    self._options.onComplete(id, name, {"error": "serverError"});
                 } else {
                     self._options.onComplete(id, name, {});
                 }


### PR DESCRIPTION
This patch makes quickupload display the serverError message in case an
upload request dies with HTTP status code 500.

The previous behaviour was that an error was indicated but no details about the type of error were given.
