### PR TITLE
More dexterity-related fixes

### DIFF
--- a/collective/quickupload/__init__.py
+++ b/collective/quickupload/__init__.py
@@ -2,10 +2,21 @@
 """
 
 import logging
+import pkg_resources
 from zope.i18n import MessageFactory
+
+
+try:
+    pkg_resources.get_distribution('plone.dexterity')
+except pkg_resources.DistributionNotFound:
+    HAS_DEXTERITY = False
+else:
+    HAS_DEXTERITY = True
+
 logger = logging.getLogger("collective.quickupload")
 
 siteMessageFactory = MessageFactory("collective.quickupload")
+
 
 def initialize(context):
     """Initializer called when used as a Zope 2 product."""

--- a/collective/quickupload/portlet/vocabularies.py
+++ b/collective/quickupload/portlet/vocabularies.py
@@ -7,20 +7,15 @@ from zope.interface import implements
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleVocabulary
 from zope.schema.vocabulary import SimpleTerm
-from zope.schema import getFieldsInOrder
 
-from Products.ATContentTypes.interfaces import IFileContent, IImageContent
 from Products.CMFCore.utils import getToolByName
 
 from collective.quickupload.browser.quick_upload import _listTypesForInterface
+from collective.quickupload import HAS_DEXTERITY
 from collective.quickupload import siteMessageFactory as _
 
-try:
+if HAS_DEXTERITY:
     from plone.dexterity.interfaces import IDexterityFTI
-    from plone.namedfile.interfaces import INamedFileField, INamedImageField
-    HAS_DEXTERITY = True
-except:
-    HAS_DEXTERITY = False
 
 
 def _infoDictForType(portal, ptype):
@@ -33,13 +28,17 @@ def _infoDictForType(portal, ptype):
     portal_types = getToolByName(portal, 'portal_types')
     type_info = getattr(portal_types, ptype)
     title = type_info.Title()
-    product = type_info.product
+    if HAS_DEXTERITY and IDexterityFTI.providedBy(type_info):
+        product = type_info.klass
+    else:
+        product = type_info.product
     type_ui_info = ("%s (portal type: %s, product: %s)" %
                     (portal.translate(title, default=title), ptype, product))
     return {
         'portal_type': ptype,
         'type_ui_info': type_ui_info
-        }
+    }
+
 
 class UploadFileTypeVocabulary(object):
     """Vocabulary factory for file type upload
@@ -49,25 +48,35 @@ class UploadFileTypeVocabulary(object):
     def __call__(self, context):
         context = getattr(context, 'context', context)
         portal = getToolByName(context, 'portal_url').getPortalObject()
-        items = [SimpleTerm('auto', 'auto', context.translate(_('label_default_portaltype_configuration',
-                                                      default=u'Default configuration (Content Type Registry).')))]
-        archetype_tool = getToolByName(context, 'archetype_tool', None)
-        if archetype_tool:
-            flt = [_infoDictForType(portal, tipe) for tipe in _listTypesForInterface(portal, IFileContent)]
-            ilt = [_infoDictForType(portal, tipe) for tipe in _listTypesForInterface(portal, IImageContent)]
-            items.extend([SimpleTerm(t['portal_type'], t['portal_type'], t['type_ui_info'])
-                      for t in flt])
-            file_types = [t['portal_type'] for t in flt]
-            items.extend([SimpleTerm(t['portal_type'], t['portal_type'], t['type_ui_info'])
-                      for t in ilt if t['portal_type'] not in file_types])
+        items = [
+            SimpleTerm(
+                'auto', 'auto', context.translate(_(
+                'label_default_portaltype_configuration',
+                default=u'Default configuration (Content Type Registry).'))
+            )
+        ]
 
-        for fti in portal.portal_types.objectValues():
-            if HAS_DEXTERITY and IDexterityFTI.providedBy(fti):
-                fields = getFieldsInOrder(fti.lookupSchema())
-                for fieldname, field in fields:
-                    if INamedFileField.providedBy(field) or INamedImageField.providedBy(field):
-                        items.append(SimpleTerm(fti.getId(), fti.getId(), fti.Title()))
-                        break
+        flt = [
+            _infoDictForType(portal, tipe) for tipe in
+            _listTypesForInterface(portal, 'file')
+        ]
+        ilt = [
+            _infoDictForType(portal, tipe) for tipe in
+            _listTypesForInterface(portal, 'image')
+        ]
+        items.extend([
+            SimpleTerm(
+                t['portal_type'], t['portal_type'], t['type_ui_info']
+            )
+            for t in flt
+        ])
+        file_types = [t['portal_type'] for t in flt]
+        items.extend([
+            SimpleTerm(
+                t['portal_type'], t['portal_type'], t['type_ui_info']
+            )
+            for t in ilt if t['portal_type'] not in file_types
+        ])
 
         return SimpleVocabulary(items)
 


### PR DESCRIPTION
This pull-request continues #26
If the portlet is configured to filter by portal_type, we also need to make sure that we don't depend on the existence of the archetype_tool.
Therefore, `_listTypesForInterface` in quick_upload now takes care of handling AT vs dexterity. Note: the signature has changed. Instead of taking an interface as argument (previously this was AT-specific), it takes a string, either "file" or "image". The method then looks up the correct interface for the requested type, based on whether AT or dexterity is present.

The `UploadFileTypeVocabulary` for the portlet has gotten simpler, since all distinction between AT and dexterity has been moved to `_listTypesForInterface`.
(I also did some pep8 / flake8 cleanup, so that the diff seems larger than it actually is)
