### PR TITLE
Keep calm and carry on

### DIFF
--- a/collective/quickupload/portlet/vocabularies.py
+++ b/collective/quickupload/portlet/vocabularies.py
@@ -63,7 +63,13 @@ class UploadFileTypeVocabulary(object):
 
         for fti in portal.portal_types.objectValues():
             if HAS_DEXTERITY and IDexterityFTI.providedBy(fti):
-                fields = getFieldsInOrder(fti.lookupSchema())
+                try:
+                    schema = fti.lookupSchema()
+                except ImportError:
+                    # this dexterity type was changed/removed in an improper way
+                    # no need to punish, just fail gracefully
+                    continue
+                fields = getFieldsInOrder(schema)
                 for fieldname, field in fields:
                     if INamedFileField.providedBy(field) or INamedImageField.providedBy(field):
                         items.append(SimpleTerm(fti.getId(), fti.getId(), fti.Title()))


### PR DESCRIPTION
If a user adds a dexterity type programmatically and then doesn't remove it manually from the fti, the portlet barfs. In this case, its best to just not list the type. bug in the wild!
