### PR TITLE
Add check for flash fallback v3_v4 upgrade method

### DIFF
--- a/collective/quickupload/upgrades/upgrades.py
+++ b/collective/quickupload/upgrades/upgrades.py
@@ -22,7 +22,8 @@ def v3_v4(context):
     #Add property to quickupload property sheet
     ptool = getToolByName(context, 'portal_properties')
     qu_props = ptool.get('quickupload_properties')
-    qu_props._setProperty('use_flash_as_fallback', False, 'boolean')
+    if not qu_props.hasProperty('use_flash_as_fallback'):
+        qu_props._setProperty('use_flash_as_fallback', False, 'boolean')
 
 
 def v4_v5(context):


### PR DESCRIPTION
If you don't check for the existence of the property, the upgrade results in an error (Module collective.quickupload.upgrades.upgrades, line 25, in v3_v4 - Module OFS.PropertyManager, line 184, in _setProperty - BadRequest: Invalid or duplicate property id)
