### PR TITLE
Use same function to detect mimetypes in flash & quick upload.

### DIFF
--- a/collective/quickupload/browser/quick_upload.py
+++ b/collective/quickupload/browser/quick_upload.py
@@ -12,6 +12,7 @@ from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.Sessions.SessionDataManager import SessionDataManagerErr
 from ZPublisher.HTTPRequest import HTTPRequest
+from ZPublisher.HTTPRequest import FileUpload
 from collective.quickupload import HAS_DEXTERITY
 from collective.quickupload import logger
 from collective.quickupload import siteMessageFactory as _
@@ -583,7 +584,7 @@ class QuickUploadFile(QuickUploadAuthenticate):
 
         file_name = request.form.get("Filename", "")
         file_data = request.form.get("Filedata", None)
-        content_type = mimetypes.guess_type(file_name)[0]
+        content_type = get_content_type(context, file_data, file_name)
         portal_type = request.form.get('typeupload', '')
         title = request.form.get("title", None)
         description = request.form.get("description", None)
@@ -783,6 +784,8 @@ class QuickUploadFile(QuickUploadAuthenticate):
 
 
 def get_content_type(context, file_data, filename):
+    if isinstance(file_data, FileUpload):
+        file_data = file_data.read()
     content_type = mimetypes.guess_type(filename)[0]
     # sometimes plone mimetypes registry could be more powerful
     if not content_type:

--- a/collective/quickupload/tests/test_mimetypes.py
+++ b/collective/quickupload/tests/test_mimetypes.py
@@ -3,6 +3,8 @@ from collective.quickupload.testing import QUICKUPLOAD_INTEGRATION_TESTING
 import os.path
 from collective.quickupload.browser.quick_upload import get_content_type
 from Products.CMFCore.utils import getToolByName
+from ZPublisher.HTTPRequest import FileUpload
+import cgi
 
 class TestMimetypes(unittest.TestCase):
 
@@ -12,6 +14,10 @@ class TestMimetypes(unittest.TestCase):
         self.portal = self.layer['portal']
         file_ = open("%s/testfile_mimetypes.txt" % os.path.split(__file__)[0], 'r')
         self.file_data = file_.read()
+        fieldstorage = cgi.FieldStorage()
+        fieldstorage.file = file_
+        fieldstorage.filename = 'testfile_mimetypes.txt'
+        self.fileupload = FileUpload(fieldstorage)
         mtr = getToolByName(self.portal, 'mimetypes_registry')
         mtr.manage_addMimeType('Only globs mimetype', ['application/x-only-glob'], [], 'application.png', globs=['*.onlyglob'])
         mtr.manage_addMimeType('Only extension mimetype', ['application/x-only-ext'], ['onlyext'], 'application.png')
@@ -27,4 +33,7 @@ class TestMimetypes(unittest.TestCase):
     def test_recognized_by_python(self):
         content_type = get_content_type(self.portal, self.file_data, 'dummy.txt')
         self.assertEqual('text/plain', content_type)
-        
+
+    def test_fileupload_instance(self):
+        content_type = get_content_type(self.portal, self.fileupload, 'dummy.txt')
+        self.assertEqual('text/plain', content_type)

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,8 @@ Changelog
 1.6.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use same function to detect mimetypes in flash & quick upload.
+  [tschanzt]
 
 
 1.6.4 (2014-06-03)


### PR DESCRIPTION
I updated the flash_upload_file function to detect mimetypes the same way the quickupload function does. /cc @buchi 
