### PR TITLE
Move handling of ConflictErrors to client side.

### DIFF
--- a/collective/quickupload/browser/quick_upload.py
+++ b/collective/quickupload/browser/quick_upload.py
@@ -24,6 +24,7 @@ from collective.quickupload.interfaces import IQuickUploadFileFactory
 from collective.quickupload.interfaces import IQuickUploadFileUpdater
 from collective.quickupload.interfaces import IQuickUploadNotCapable
 from plone.i18n.normalizer.interfaces import IUserPreferredFileNameNormalizer
+from ZODB.POSException import ConflictError
 from zope.component import getUtility
 from zope.i18n import translate
 from zope.schema import getFieldsInOrder
@@ -724,6 +725,10 @@ class QuickUploadFile(QuickUploadAuthenticate):
                 try:
                     f = updater(overwritten_file, file_name, title,
                                 description, content_type, file_data)
+                except ConflictError:
+                    # Allow Zope to retry up to three times, and if that still
+                    # fails, handle ConflictErrors on client side if necessary
+                    raise
                 except Exception, e:
                     logger.error(
                         "Error updating %s file: %s", file_name, str(e)
@@ -740,6 +745,10 @@ class QuickUploadFile(QuickUploadAuthenticate):
                 try:
                     f = factory(file_name, title, description, content_type,
                                 file_data, portal_type)
+                except ConflictError:
+                    # Allow Zope to retry up to three times, and if that still
+                    # fails, handle ConflictErrors on client side if necessary
+                    raise
                 except Exception, e:
                     logger.error(
                         "Error creating %s file: %s", file_name, str(e)

--- a/collective/quickupload/browser/static/fileuploader.js
+++ b/collective/quickupload/browser/static/fileuploader.js
@@ -845,7 +845,11 @@ qq.UploadHandlerXhr.prototype = {
                     self._options.onComplete(id, name, response);
 
                 } else if (xhr.status == 500){
-                    self._options.onComplete(id, name, {"error": "serverError"});
+                    if (xhr.responseText.indexOf("ZODB.POSException.ConflictError") > -1) {
+                        self._options.onComplete(id, name, {"error": "serverErrorZODBConflict"});
+                    } else {
+                        self._options.onComplete(id, name, {"error": "serverError"});
+                    }
                 } else {
                     self._options.onComplete(id, name, {});
                 }

--- a/collective/quickupload/browser/uploadcapable.py
+++ b/collective/quickupload/browser/uploadcapable.py
@@ -20,7 +20,6 @@ from AccessControl import Unauthorized
 from Acquisition import aq_inner
 from Products.Archetypes.event import ObjectEditedEvent
 from Products.statusmessages.interfaces import IStatusMessage
-from ZODB.POSException import ConflictError
 from collective.quickupload import logger
 from collective.quickupload import siteMessageFactory as _
 from collective.quickupload.interfaces import IQuickUploadCapable
@@ -98,9 +97,6 @@ class QuickUploadCapableFileFactory(object):
                                           title=title, description=description)
                 except Unauthorized:
                     error = u'serverErrorNoPermission'
-                except ConflictError:
-                    # rare with xhr upload / happens sometimes with flashupload
-                    error = u'serverErrorZODBConflict'
                 except ValueError:
                     error = u'serverErrorDisallowedType'
                 except Exception, e:

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,10 @@ Changelog
 1.6.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Move handling of ConflictErrors to client side.
+  This allows Zope to resolve most write conflicts by reytring the transaction.
+  (see https://github.com/collective/collective.quickupload/pull/49).
+  [lgraf]
 
 
 1.6.6 (2014-12-09)


### PR DESCRIPTION
Catching `ConflictError` previously prevented Zope from retrying the transaction (up to three times), and therefore resolving most write conflicts.

This change excludes ConflictErrors from the blanket `try..except Exception` around the factory calls, and removes its special handling from the default `QuickUploadCapableFileFactory`.

For XHR uploads, the conflict errors are now detected client side, and the same message as before is displayed. For Flash upload or classic form post (IE < 8), a generic error message should be displayed.

@phgross @maethu @jone