### PR TITLE
Add property 'Choose unique file id'.

### DIFF
--- a/collective/quickupload/browser/quick_upload.py
+++ b/collective/quickupload/browser/quick_upload.py
@@ -677,11 +677,12 @@ class QuickUploadFile(QuickUploadAuthenticate):
 
         # overwrite file
         try:
-            newid = get_id_from_filename(file_name, context)
+            newid = get_id_from_filename(
+                file_name, context, unique=self.qup_prefs.object_unique_id)
         except MissingExtension:
             return json.dumps({u'error': u'missingExtension'})
 
-        if newid in context or file_name in context:
+        if (newid in context or file_name in context) and not self.qup_prefs.object_unique_id:
             updated_object = context.get(newid, False) or context[file_name]
             mtool = getToolByName(context, 'portal_membership')
             override_setting = self.qup_prefs.object_override

--- a/collective/quickupload/browser/quickupload_settings.py
+++ b/collective/quickupload/browser/quickupload_settings.py
@@ -114,7 +114,9 @@ class IQuickUploadControlPanel(Interface):
                     u"Checked: Your files will never be overridden and you'll "
                     u"never get a 'file already exists' error message because "
                     u"each file has its unique id."
-                    u"Non-Checked: The id will not be unique."),
+                    u"Non-Checked: The id will not be unique. "
+                    u"The 'Override by upload file' option is considered "
+                    u"when a conflict happens."),
         default=False,
         required=False)
 

--- a/collective/quickupload/browser/quickupload_settings.py
+++ b/collective/quickupload/browser/quickupload_settings.py
@@ -106,6 +106,18 @@ class IQuickUploadControlPanel(Interface):
         default=2,
         required=True)
 
+    object_unique_id = Bool(
+        title=_(u"title_object_unique_id", default=u"Choose unique file id"),
+        description=_(
+            u"description_object_unique_id",
+            default=u"Choose a unique id for each uploaded file."
+                    u"Checked: Your files will never be overridden and you'll "
+                    u"never get a 'file already exists' error message because "
+                    u"each file has its unique id."
+                    u"Non-Checked: The id will not be unique."),
+        default=False,
+        required=False)
+
     object_override = Bool(
         title=_(u"title_object_override", default=u"Override by upload file"),
         description=_(
@@ -191,6 +203,14 @@ class QuickUploadControlPanelAdapter(SchemaAdapterBase):
         self.quProps._updateProperty('sim_upload_limit', value)
 
     sim_upload_limit = property(get_sim_upload_limit, set_sim_upload_limit)
+
+    def get_object_unique_id(self):
+        return self.quProps.getProperty('object_unique_id')
+
+    def set_object_unique_id(self, value):
+        self.quProps._updateProperty('object_unique_id', value)
+
+    object_unique_id = property(get_object_unique_id, set_object_unique_id)
 
     def get_object_override(self):
         return self.quProps.getProperty('object_override')

--- a/collective/quickupload/browser/uploadcapable.py
+++ b/collective/quickupload/browser/uploadcapable.py
@@ -48,7 +48,7 @@ class MissingExtension(Exception):
     """Exception when the filename has no extension."""
 
 
-def get_id_from_filename(filename, context):
+def get_id_from_filename(filename, context, unique=False):
     charset = getattr(context, 'getCharset', None) and context.getCharset()\
         or 'utf-8'
     name = filename.decode(charset).rsplit('.', 1)
@@ -57,6 +57,8 @@ def get_id_from_filename(filename, context):
     normalizer = component.getUtility(IIDNormalizer)
     newid = '.'.join((normalizer.normalize(name[0]), name[1]))
     newid = newid.replace('_', '-').replace(' ', '-').lower()
+    if unique:
+        newid = INameChooser(context).chooseName(newid, context)
     return newid
 
 

--- a/collective/quickupload/locales/collective.quickupload.pot
+++ b/collective/quickupload/locales/collective.quickupload.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -85,7 +85,7 @@ msgstr ""
 msgid "Content type"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr ""
 
@@ -137,7 +137,7 @@ msgstr ""
 msgid "Quick Upload"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr ""
 
@@ -197,11 +197,11 @@ msgid "description_fill_titles"
 msgstr ""
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr ""
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
 msgstr ""
@@ -295,11 +295,11 @@ msgid "title_fill_titles"
 msgstr ""
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr ""
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
 msgid "title_object_unique_id"
 msgstr ""

--- a/collective/quickupload/locales/collective.quickupload.pot
+++ b/collective/quickupload/locales/collective.quickupload.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,27 +17,27 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.quickupload\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr ""
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr ""
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr ""
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr ""
 
@@ -45,91 +45,91 @@ msgstr ""
 msgid "Batch upload files."
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr ""
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr ""
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr ""
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr ""
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr ""
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr ""
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr ""
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr ""
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr ""
 
 msgid "Files"
 msgstr ""
 
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr ""
 
 msgid "Image"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr ""
 
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr ""
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr ""
 
@@ -137,35 +137,35 @@ msgstr ""
 msgid "Quick Upload"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr ""
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr ""
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr ""
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr ""
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr ""
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr ""
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr ""
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr ""
 
@@ -173,56 +173,61 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr ""
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr ""
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr ""
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr ""
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr ""
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr ""
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr ""
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr ""
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr ""
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr ""
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
 msgid "description_use_flash_fallback"
 msgstr ""
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
 msgid "description_use_flashupload"
 msgstr ""
 
@@ -242,13 +247,13 @@ msgid "label_clear_queue"
 msgstr ""
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr ""
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr ""
 
@@ -257,65 +262,70 @@ msgstr ""
 msgid "label_upload_files"
 msgstr ""
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr ""
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr ""
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr ""
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr ""
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr ""
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr ""
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr ""
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr ""
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr ""
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr ""
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr ""
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr ""
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr ""
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr ""
 

--- a/collective/quickupload/locales/cs/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/cs/LC_MESSAGES/collective.quickupload.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: 2013-05-10 08:09+0100\n"
 "Last-Translator: Radim Novotny <novotny.radim@gmail.com>\n"
 "Language-Team: AOW <aow@aow.cz>\n"
@@ -17,27 +17,27 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.quickupload\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr "soubory/souborů bylo úspěšně nahráno."
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr "soubory/souborů skončilo s chybou"
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr "Byl detekován konfilkt databáze při nahrávání souboru: "
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr "Vše"
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr "Všechny soubory byly úspěšně nahrány."
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr "Audio soubory"
 
@@ -45,91 +45,91 @@ msgstr "Audio soubory"
 msgid "Batch upload files."
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr "Název"
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr "Procházet"
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr "Vyberte audio soubory, které chcete nahrát"
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr "Vyberte soubor k nahrání ${ext}"
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr "Vyberte flash soubory, které chcete nahrát"
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr "Vyberte obrázky, které chcete nahrát"
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr "Vyberte typ souboru, který se bude nahrávat. Obrázky, audio souboru, video ..."
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr "Vyberte typ položky v portálu, která bude vytvořena při nahrání souboru. Výchozí nastavení použije nastavení portálu, které rozhoduje na základě typu nahrávaného souboru."
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr "Vyberte video soubory, které chcete nahrát"
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr "Typ souboru"
 
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr "Nastavení použití quick upload nástroje."
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr "Přetáhněte sem soubory, které chcete nahrát"
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr "Chyba"
 
 msgid "Files"
 msgstr ""
 
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr "Rychlé nahrání souborů"
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr "Flash soubory"
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr "Pokud není vyplněno, název portletu bude <název typu> + \"Quick Upload\"."
 
 msgid "Image"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr "Obrázky"
 
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr "Rychlé nahrání obrázků"
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr "Typ souborů"
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr "Povoleno pouze:"
 
@@ -137,35 +137,35 @@ msgstr "Povoleno pouze:"
 msgid "Quick Upload"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr "Nastavení Quick Upload"
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr "Vybrané položky obsahují prázdný soubor nebo složku:"
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr "Chyba na serveru. Kontaktujte prosím technickou podporu nebo to zkuste znovu."
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr "Soubor se stejným názvem již na serveru existuje:"
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr "Soubor na neplatnou příponu:"
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr "Soubor nemá žádnou příponu:"
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr "Soubor je příliš velký:"
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr "Tento typ souboru není v této složce povolen:"
 
@@ -173,56 +173,63 @@ msgstr "Tento typ souboru není v této složce povolen:"
 msgid "Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr "Video soubory"
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr "Nemáte oprtávnění přidávat tento typ položek do tohoto umístění."
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr "Zaškrtněte, pokud chcete nahrávání spustit automaticky ihned po vybrání souborů, bez potřeby klikat na tlačítko k zahájení nahrávání. V takovém případě nebude možné k nahrávaným souborům přiřadit nadpis a popis."
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr "Pokud je zaškrtnuto, pak bude možné ke každému souboru vložit popis."
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr "Pokud je zaškrtnuto, pak bude možné ke každému souboru vložit nadpis."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr ""
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr ""
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr ""
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr "Počet souborů, které bude možné nahrávat současně. Soubory nad tento limit budou čekat dokud se nenahrají soubory před nimi. 0 = bez omezení."
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr "Limit velikosti každého souboru v kB. 0 = bez omezení."
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
+#, fuzzy
 msgid "description_use_flash_fallback"
 msgstr "Zaškrtněte, pokud chcete v IE použít Flash upload komponentu pokud není možné použít javascript komponentu."
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
+#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Standardně je upload komponenta čistě javascriptové řešení. Zaškrtněte toto políčko, pokud ji chcete nahradit za Flash komponentu. Flash komponenta bude fungovat ve starých prohlížečích (IE 7, 8) ale má mnoho problémů souvisejících s HTTPS nebo autentizací."
 
@@ -242,13 +249,13 @@ msgid "label_clear_queue"
 msgstr "Vymazat frontu"
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr "Výchozí nastavení (content type registry)"
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr "${medialabel} - rychlé nahrání"
 
@@ -257,65 +264,70 @@ msgstr "${medialabel} - rychlé nahrání"
 msgid "label_upload_files"
 msgstr "Nahrát soubory"
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr "maximální velikost souboru je:"
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr "Soubor ${filename} byl nahrazen.\""
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr "vyberte prosím soubory znovu"
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr "zkuste to prosím znovu."
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr "Automatické nahrání po vybrání souborů"
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr "Vyplnit popis před nahráním souborů"
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr "Vyplnit název před nahráním souborů"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr ""
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr ""
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr ""
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr "Maximální počet současně nahrávaných souborů"
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr "Omezení velikosti"
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr "Použít flash pro IE"
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr "Použít Flash Upload"
 

--- a/collective/quickupload/locales/cs/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/cs/LC_MESSAGES/collective.quickupload.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: 2013-05-10 08:09+0100\n"
 "Last-Translator: Radim Novotny <novotny.radim@gmail.com>\n"
 "Language-Team: AOW <aow@aow.cz>\n"
@@ -85,7 +85,7 @@ msgstr "Vyberte video soubory, které chcete nahrát"
 msgid "Content type"
 msgstr "Typ souboru"
 
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr "Nastavení použití quick upload nástroje."
 
@@ -137,7 +137,7 @@ msgstr "Povoleno pouze:"
 msgid "Quick Upload"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr "Nastavení Quick Upload"
 
@@ -197,11 +197,11 @@ msgid "description_fill_titles"
 msgstr "Pokud je zaškrtnuto, pak bude možné ke každému souboru vložit nadpis."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr ""
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
 msgstr ""
@@ -297,11 +297,11 @@ msgid "title_fill_titles"
 msgstr "Vyplnit název před nahráním souborů"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr ""
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
 msgid "title_object_unique_id"
 msgstr ""

--- a/collective/quickupload/locales/cs/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/cs/LC_MESSAGES/collective.quickupload.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-25 09:49+0000\n"
+"POT-Creation-Date: 2015-09-28 06:47+0000\n"
 "PO-Revision-Date: 2013-05-10 08:09+0100\n"
 "Last-Translator: Radim Novotny <novotny.radim@gmail.com>\n"
 "Language-Team: AOW <aow@aow.cz>\n"
@@ -223,13 +223,11 @@ msgstr "Limit velikosti každého souboru v kB. 0 = bez omezení."
 
 #. Default: "Check if you want to use flash uload as fallback for IE"
 #: ../browser/quickupload_settings.py:33
-#, fuzzy
 msgid "description_use_flash_fallback"
 msgstr "Zaškrtněte, pokud chcete v IE použít Flash upload komponentu pokud není možné použít javascript komponentu."
 
 #. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
 #: ../browser/quickupload_settings.py:18
-#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Standardně je upload komponenta čistě javascriptové řešení. Zaškrtněte toto políčko, pokud ji chcete nahradit za Flash komponentu. Flash komponenta bude fungovat ve starých prohlížečích (IE 7, 8) ale má mnoho problémů souvisejících s HTTPS nebo autentizací."
 

--- a/collective/quickupload/locales/de/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/de/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-25 09:49+0000\n"
+"POT-Creation-Date: 2015-09-28 06:47+0000\n"
 "PO-Revision-Date: 2012-10-30 14:23+0100\n"
 "Last-Translator: Pavel Bogdanovic <pb@prontonet.eu>\n"
 "Language-Team: \n"
@@ -226,13 +226,11 @@ msgstr "Dateigrößenlimit pro Datei in KB, 0 = kein Limit"
 
 #. Default: "Check if you want to use flash uload as fallback for IE"
 #: ../browser/quickupload_settings.py:33
-#, fuzzy
 msgid "description_use_flash_fallback"
 msgstr "Wenn diese Option aktiviert ist, wird für den IE Flash als Fallback für MultiUpload benutzt."
 
 #. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
 #: ../browser/quickupload_settings.py:18
-#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Standardmäßig wird nur JavaScript zum Hochladen verwendet. Aktivieren Sie diese Option, um ein Flash-basiertes Upload-Skript zu verwenden. Moderne Browser unterstützen das JavaScript-Tool besser. Der Flash-Upload funktioniert bei älteren Browsern (MSIE 7, MSIE 8) besser, hat aber Probleme bei https und in Kombination mit HTTP-Authentifizierung."
 
@@ -306,7 +304,6 @@ msgstr ""
 
 #. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
-#, fuzzy
 msgid "title_object_unique_id"
 msgstr "Wähle für jedes File eine eindeutige ID"
 

--- a/collective/quickupload/locales/de/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/de/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: 2012-10-30 14:23+0100\n"
 "Last-Translator: Pavel Bogdanovic <pb@prontonet.eu>\n"
 "Language-Team: \n"
@@ -16,27 +16,27 @@ msgstr ""
 "Domain: collective.quickupload\n"
 "X-Is-Fallback-For: de-at de-li de-lu de-ch de-de\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr "Dateien wurden erfolgreich hochgeladen, "
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr "Fehler beim Hochladen der Dateien."
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr "Beim Hochladen der folgenden Datei ist ein Fehler aufgetreten:"
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr "Alle"
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr "Alle Dateien wurden erfolgreich hochgeladen."
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr "Audiodateien"
 
@@ -44,56 +44,56 @@ msgstr "Audiodateien"
 msgid "Batch upload files."
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr "Box Titel"
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr "Durchsuchen"
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr "Musikdateien auswählen."
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr "Datei auswählen: ${ext}"
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr "Flashdatei auswählen"
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr "Bilddateien auswählen."
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr "Wählen Sie einen erlaubten Medientyp für den Datei-Upload. Bild, Audio, Video ..."
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr "Wählen Sie die Standardkonfiguration um die Einstellungen der content type registry zu übernehmen."
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr "Videodateien auswählen"
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr "Inhaltstyp"
 
 #. Default: "Control how the quick upload tool is used."
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr "Konfigurieren Sie, wie der Quick Upload benutzt werden kann."
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr "Ziehen Sie Dateien in diesen Bereich"
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
@@ -101,37 +101,37 @@ msgid "Files"
 msgstr ""
 
 #. Default: "Files Quick Upload"
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr "Datei Quick Upload"
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr "Flashdateien"
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr "Bei leerem Feld wird der Titel automatisch in Abhängigkeit der Medientypauswahl vergeben."
 
 msgid "Image"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr "Bilder"
 
 #. Default: "Images Quick Upload"
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr "Bilder Quick Upload"
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr "Medientyp"
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr "Nur erlaubt:"
 
@@ -140,35 +140,35 @@ msgid "Quick Upload"
 msgstr ""
 
 #. Default: "Quick Upload settings"
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr "Einstellungen für den Quick Upload"
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr "Unter den ausgwählten Elementen hat es eine leere Datei oder einen leeren Ordner"
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr "Server Fehler, bitte kontaktieren Sie den Support und/oder versuchen Sie es noch einmal."
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr "Es existiert bereits eine Datei mit dem folgendem Name:"
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr "Die folgende Datei hat eine ungültige Dateiendung:"
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr "Die Datei hat keine Dateiendung:"
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr "Die folgende Datei ist zu gross:"
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr "Diese Art von Dokument ist in diesem Ordner nicht erlaubt."
 
@@ -176,56 +176,63 @@ msgstr "Diese Art von Dokument ist in diesem Ordner nicht erlaubt."
 msgid "Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr "Videodateien"
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr "Sie dürfen diesen Inhalt hier nicht hinzufügen."
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr "Auswählen, wenn die Dateien sofort nach dem Auswählen hochgeladen werden sollen. Bitte beachten, dass in diesem Fall keine Titel oder Beschreibung vergeben werden können."
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr "Wenn diese Option aktiviert ist, können Sie Beschreibung vor dem Hochladen vergeben. Deaktivieren Sie diese Option, wenn Sie keine Beschreibung brauchen."
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr "Wenn diese Option aktiviert ist, können Sie Titel vor dem Hochladen vergeben. Deaktivieren Sie diese Option, wenn Sie keine Titel brauchen."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr ""
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr "Wählt eine einmalige ID für jedes hochgeladene File. Ausgewählt: Es werden keine Files überschrieben. Wenn ein gleiches Dokument bereits existiert, wird das neue Dokument unter einem neuen Namen hochgeladen. Nicht ausgewählt: Die ID kann doppelt sein. In diesem Fall wird das File entweder überschrieben oder es gibt eine Fehlermeldung."
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr ""
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr "Überzählige Dateiuploads landen in einer Warteschlange, 0 = keine Begrenzung"
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr "Dateigrößenlimit pro Datei in KB, 0 = kein Limit"
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
+#, fuzzy
 msgid "description_use_flash_fallback"
 msgstr "Wenn diese Option aktiviert ist, wird für den IE Flash als Fallback für MultiUpload benutzt."
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
+#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Standardmäßig wird nur JavaScript zum Hochladen verwendet. Aktivieren Sie diese Option, um ein Flash-basiertes Upload-Skript zu verwenden. Moderne Browser unterstützen das JavaScript-Tool besser. Der Flash-Upload funktioniert bei älteren Browsern (MSIE 7, MSIE 8) besser, hat aber Probleme bei https und in Kombination mit HTTP-Authentifizierung."
 
@@ -245,13 +252,13 @@ msgid "label_clear_queue"
 msgstr "Warteschlange löschen"
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr "Standard konfiguration (Content Type Registry)."
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr "${medialabel} Quick Upload"
 
@@ -260,65 +267,70 @@ msgstr "${medialabel} Quick Upload"
 msgid "label_upload_files"
 msgstr "Dateien hochladen"
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr "Die maximale Grösse ist:"
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr "Datei ${filename} wurde ersetzt"
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr "bitte wählen Sie die Dateien erneut aus."
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr "bitte noch einmal versuchen."
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr "Automatisch nach Auswahl hochladen"
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr "Geben Sie einen Beschreibung vor dem Hochladen ein"
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr "Geben Sie einen Titel vor dem Hochladen ein"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr ""
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr "Wähle für jedes File eine eindeutige ID"
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr ""
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr "Maximale Anzahl gleichzeitiger Uploads"
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr "Dateigrößenlimit"
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr "Benutze Flash Mutliupload als Fallback für IE"
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr "Flash-Upload benutzen"
 

--- a/collective/quickupload/locales/de/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/de/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: 2012-10-30 14:23+0100\n"
 "Last-Translator: Pavel Bogdanovic <pb@prontonet.eu>\n"
 "Language-Team: \n"
@@ -85,7 +85,7 @@ msgid "Content type"
 msgstr "Inhaltstyp"
 
 #. Default: "Control how the quick upload tool is used."
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr "Konfigurieren Sie, wie der Quick Upload benutzt werden kann."
 
@@ -140,7 +140,7 @@ msgid "Quick Upload"
 msgstr ""
 
 #. Default: "Quick Upload settings"
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr "Einstellungen für den Quick Upload"
 
@@ -200,14 +200,14 @@ msgid "description_fill_titles"
 msgstr "Wenn diese Option aktiviert ist, können Sie Titel vor dem Hochladen vergeben. Deaktivieren Sie diese Option, wenn Sie keine Titel brauchen."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr ""
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
-msgstr "Wählt eine einmalige ID für jedes hochgeladene File. Ausgewählt: Es werden keine Files überschrieben. Wenn ein gleiches Dokument bereits existiert, wird das neue Dokument unter einem neuen Namen hochgeladen. Nicht ausgewählt: Die ID kann doppelt sein. In diesem Fall wird das File entweder überschrieben oder es gibt eine Fehlermeldung."
+msgstr "Wählt eine einmalige ID für jedes hochgeladene File. Ausgewählt: Es werden keine Files überschrieben. Wenn ein gleiches Dokument bereits existiert, wird das neue Dokument unter einem neuen Namen hochgeladen. Nicht ausgewählt: Die ID kann doppelt sein. In diesem Fall entscheidet die 'Override by upload file'-Checkbox über das weitere Verhalten."
 
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
 #: ../browser/quickupload_settings.py:53
@@ -300,12 +300,13 @@ msgid "title_fill_titles"
 msgstr "Geben Sie einen Titel vor dem Hochladen ein"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr ""
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
+#, fuzzy
 msgid "title_object_unique_id"
 msgstr "Wähle für jedes File eine eindeutige ID"
 

--- a/collective/quickupload/locales/es/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/es/LC_MESSAGES/collective.quickupload.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: 2013-06-17 02:12-0430\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: ES <LL@li.org>\n"
@@ -21,27 +21,27 @@ msgstr ""
 "X-Generator: Virtaal 0.7.1\n"
 "X-Is-Fallback-For: es-ar es-bo es-cl es-co es-cr es-do es-ec es-es es-sv es-gt es-hn es-mx es-ni es-pa es-py es-pe es-pr es-us es-uy es-ve\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr " archivos cargados exitosamente, "
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr " cargas retornaron un error."
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr "Ocurrió un conflicto en la base de datos durante la carga de este archivo:"
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr "Todos"
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr "Todos los archivos fueron cargados con éxito."
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr "Archivos de audio"
 
@@ -49,91 +49,91 @@ msgstr "Archivos de audio"
 msgid "Batch upload files."
 msgstr "Archivos cargados por lotes."
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr "Título de la caja"
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr "Mostrar"
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr "Elija los archivos de audio que va a cargar"
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr "Elija el archivo para la carga: ${ext}"
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr "Elija los archivos flash que va a cargar"
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr "Elija las imágenes que va a cargar"
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr "Elija el tipo de medio usado para la carga de archivos: imagenes, audio, video..."
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr "Elija el tipo de contenido usado para la carga de archivos. Utilice la configuración por defecto para seleccionar automáticamente el tipo de contenido en dependencia de la configuración de content_type_registry."
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr "Elija los videos que va a cargar"
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr "Tipo de contenido"
 
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr "Controla como se usa la herramienta de carga rápida."
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr "Arrastre y suelte los archivos que va a cargar"
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr "Fallo"
 
 msgid "Files"
 msgstr ""
 
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr "Carga rápida de archivos"
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr "Archivos Flash"
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr "Si el título está vacío, el título del portlet será 'Carga rápida' + del medio elegido."
 
 msgid "Image"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr "Imágenes"
 
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr "Carga rápida de imágenes"
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr "Tipo de medio"
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr "Sólo se permite:"
 
@@ -141,35 +141,35 @@ msgstr "Sólo se permite:"
 msgid "Quick Upload"
 msgstr "Carga rápida"
 
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr "Configuración de Carga rápida"
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr "Los elementos seleccionados contienen un archvio vacío o una carpeta:"
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr "Error del servidor, por favor contacte a soporte y/o intente de nuevo."
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr "Un archivo con este mismo nombre ya existe en el servidor:"
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr "Este archivo tiene una extensión no válida:"
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr "Este archivo no tiene una extensión:"
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr "Este archivo es demasiado grande:"
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr "Este tipo de elemento no es permitido en esta carpeta."
 
@@ -177,56 +177,63 @@ msgstr "Este tipo de elemento no es permitido en esta carpeta."
 msgid "Upload"
 msgstr "Cargar"
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr "Archivos de video"
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr "Usted no tiene permiso para agregar este contenido en este lugar."
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr "Si está seleccionado, la carga comenzará de forma automática después de elegir los archivos. Note que no puede elegir el título y la descripción de los archivos si utiliza está opción."
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr "Si está seleccionado, puede elegir la descripción de los archivos antes de cargarlos. No lo seleccione si no requiere descripciones."
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr "Si está seleccionado, puede elegir el título de los archivos antes de cargarlos. No lo seleccione si no requiere títulos."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr ""
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr ""
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr "Compruebe si usted quiere tener un enlace \\\"Cargar\\\" en la barra de edición. Al hacer clic se abrirá un panel para cargar a continuación el título del elemento en cuestión. Este panel es una alternativa a al portlet de \\\"Cargar\\\" y no ofrece ninguna otra configuración, como el filtrado por tipo de contenido. El panel sólo se muestra cuando el portlet \\\"Cargar\\\" no está presente."
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr "Número de archivos cargados simultáneamente, por encima de este número las cargas se pondrán en una cola. Utilice 0 si no desea especificar un límite."
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr "Tamaño límite de cada archivo en KB. Utilice 0 si no desea especificar un límite."
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
+#, fuzzy
 msgid "description_use_flash_fallback"
 msgstr "Marque esta casilla si quiere utilizar el cargador basado en Flash como reserva para el navegador IE."
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
+#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Por defecto, Quik Upload sólo utiliza la herramienta de carga escrita en JavaScript. Seleccione esta opción para reemplazarla con una herramienta de carga basada en Flash. En los navegadores modernos la herramienta JavaScript es más poderosa. La herramienta Flash tiene una interfaz más amigable en navegadores antiguos (MSIE 7, MSIE 8), pero también presenta algunos problemas: no funciona sobre canales seguros HTTPS, no funciona con autenticación HTTP..."
 
@@ -246,13 +253,13 @@ msgid "label_clear_queue"
 msgstr "Borrar la cola"
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr "Configuración por defecto (Registro de tipo contenido)."
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr "Carga rápida de ${medialabel}"
 
@@ -261,65 +268,70 @@ msgstr "Carga rápida de ${medialabel}"
 msgid "label_upload_files"
 msgstr "Carga de archivos"
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr "el tamaño máximo de los archivos es:"
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr "El archivo ${filename} ha sido remplazado"
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr "por favor selecciones archivos de nuevo sin éste."
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr "por favor intente de nuevo."
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr "Carga automática al seleccionar"
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr "Modificar la descripción antes de la carga"
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr "Modificar el título antes de la carga"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr ""
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr ""
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr "Mostrar acción \\\"Cargar\\\""
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr "Límite de cargas simultáneas"
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr "Tamaño límite"
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr "Use el cargador basado en Flash como reserva para el navegador IE."
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr "Usar carga Flash"
 

--- a/collective/quickupload/locales/es/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/es/LC_MESSAGES/collective.quickupload.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: 2013-06-17 02:12-0430\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: ES <LL@li.org>\n"
@@ -89,7 +89,7 @@ msgstr "Elija los videos que va a cargar"
 msgid "Content type"
 msgstr "Tipo de contenido"
 
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr "Controla como se usa la herramienta de carga rápida."
 
@@ -141,7 +141,7 @@ msgstr "Sólo se permite:"
 msgid "Quick Upload"
 msgstr "Carga rápida"
 
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr "Configuración de Carga rápida"
 
@@ -201,11 +201,11 @@ msgid "description_fill_titles"
 msgstr "Si está seleccionado, puede elegir el título de los archivos antes de cargarlos. No lo seleccione si no requiere títulos."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr ""
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
 msgstr ""
@@ -301,11 +301,11 @@ msgid "title_fill_titles"
 msgstr "Modificar el título antes de la carga"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr ""
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
 msgid "title_object_unique_id"
 msgstr ""

--- a/collective/quickupload/locales/es/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/es/LC_MESSAGES/collective.quickupload.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-25 09:49+0000\n"
+"POT-Creation-Date: 2015-09-28 06:47+0000\n"
 "PO-Revision-Date: 2013-06-17 02:12-0430\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: ES <LL@li.org>\n"
@@ -227,13 +227,11 @@ msgstr "Tamaño límite de cada archivo en KB. Utilice 0 si no desea especificar
 
 #. Default: "Check if you want to use flash uload as fallback for IE"
 #: ../browser/quickupload_settings.py:33
-#, fuzzy
 msgid "description_use_flash_fallback"
 msgstr "Marque esta casilla si quiere utilizar el cargador basado en Flash como reserva para el navegador IE."
 
 #. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
 #: ../browser/quickupload_settings.py:18
-#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Por defecto, Quik Upload sólo utiliza la herramienta de carga escrita en JavaScript. Seleccione esta opción para reemplazarla con una herramienta de carga basada en Flash. En los navegadores modernos la herramienta JavaScript es más poderosa. La herramienta Flash tiene una interfaz más amigable en navegadores antiguos (MSIE 7, MSIE 8), pero también presenta algunos problemas: no funciona sobre canales seguros HTTPS, no funciona con autenticación HTTP..."
 

--- a/collective/quickupload/locales/eu/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/eu/LC_MESSAGES/collective.quickupload.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: 2013-08-28 09:08+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: eu <eu@li.org>\n"
@@ -83,7 +83,7 @@ msgstr "Aukeratu kargatzeko bideo-fitxategiak"
 msgid "Content type"
 msgstr "Elementu-mota"
 
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr "Kontrolatu nola erabiltzen den 'quick upload' tresna"
 
@@ -135,7 +135,7 @@ msgstr "Hauek bakarrik onartzen dira:"
 msgid "Quick Upload"
 msgstr "Karga azkarra"
 
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr "Karga azkarraren ezarpenak"
 
@@ -195,11 +195,11 @@ msgid "description_fill_titles"
 msgstr "Aukeratuta badago fitxategien izenburuak kargatu aurretik bete ditzakezu. Ez aukeratu izenburuak behar ez badituzu."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr ""
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
 msgstr ""
@@ -295,11 +295,11 @@ msgid "title_fill_titles"
 msgstr "Kargatu aurretik izenburuak bete"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr ""
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
 msgid "title_object_unique_id"
 msgstr ""

--- a/collective/quickupload/locales/eu/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/eu/LC_MESSAGES/collective.quickupload.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-25 09:49+0000\n"
+"POT-Creation-Date: 2015-09-28 06:47+0000\n"
 "PO-Revision-Date: 2013-08-28 09:08+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: eu <eu@li.org>\n"
@@ -221,13 +221,11 @@ msgstr "Fitxategien tamaina maximoa KBtan, 0 = mugarik ez"
 
 #. Default: "Check if you want to use flash uload as fallback for IE"
 #: ../browser/quickupload_settings.py:33
-#, fuzzy
 msgid "description_use_flash_fallback"
 msgstr "Aukeratu Internet Explorer nabigatzailean flash formatuko kargatzailea erabili nahi baduzu"
 
 #. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
 #: ../browser/quickupload_settings.py:18
-#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Defektuz kargatzeko lana javascript tresna batek egiten du. Aukeratu kutxa hau Flash formatuko kargatzaile bat erabiltzeko. Nabigatzaile berrietan javascript tresna hobea da. Flash formatukoa nabigatzaile zaharretan egokiagoa da (hala nola IE7 edo IE8), baina hainbat arazo ditu: ez dabil https-rekin, ez dabil HTTP autentikazioarekin, ..."
 

--- a/collective/quickupload/locales/eu/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/eu/LC_MESSAGES/collective.quickupload.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: 2013-08-28 09:08+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: eu <eu@li.org>\n"
@@ -15,27 +15,27 @@ msgstr ""
 "Domain: DOMAIN\n"
 "X-Poedit-Language: Basque\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr " fitxategi ondo kargatu dira,"
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr " fitxategik errorea eman dute."
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr "Datu basearen errorea gertatu da fitxategi hau kargatzean:"
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr "Guztiak"
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr "Fitxategi guztiak ondo kargatu dira."
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr "Audio fitxategiak"
 
@@ -43,91 +43,91 @@ msgstr "Audio fitxategiak"
 msgid "Batch upload files."
 msgstr "Fitxategiak batera kargatu"
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr "Kutxaren izenburua"
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr "Arakatu"
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr "Aukeratu kargatzeko audio-fitxategiak"
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr "Aukeratu kargatzeko fitxategiak: ${ext}"
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr "Aukeratu kargatzeko flash-fitxategiak"
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr "Aukeratu kargatzeko irudi-fitxategiak"
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr "Fitxategi-kargarako erabiliko den formatua aukeratu: irudia, audioa, bideoa, ..."
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr "Aukeratu fitxategiak kargatzean sortuko den elementu mota. Defektuzko konfigurazioa uzten baduzu content_type_registry-ko konfigurazioa hartuko da kontuan."
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr "Aukeratu kargatzeko bideo-fitxategiak"
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr "Elementu-mota"
 
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr "Kontrolatu nola erabiltzen den 'quick upload' tresna"
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr "Kargatzeko fitxategiak arrastratu eta jaregin"
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr "Huts egin du"
 
 msgid "Files"
 msgstr ""
 
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr "Fitxategien karga azkarra"
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr "Flash fitxategiak"
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr "Izenburua hutsik badago, portletaren izenburua Irudia/Fitxategia/Bideoa + ' Azkar Kargatzea' izango da"
 
 msgid "Image"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr "Irudiak"
 
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr "Irudiak Azkar Kargatzea"
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr "Media mota"
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr "Hauek bakarrik onartzen dira:"
 
@@ -135,35 +135,35 @@ msgstr "Hauek bakarrik onartzen dira:"
 msgid "Quick Upload"
 msgstr "Karga azkarra"
 
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr "Karga azkarraren ezarpenak"
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr "Aukeratutako elementuen artean fitxategi edo karpeta huts bat dago:"
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr "Zerbitzariko errorea, jar zaitez atariaren arduradunarekin kontaktuan edo saiatu berriz."
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr "Zerbitzarian badago izen hori duen fitxategi bat:"
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr "Fitxategi honen luzapena ez da zuzena:"
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr "Fitxategi honek ez du luzapenik:"
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr "Fitxategi hau handiegia da:"
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr "Karpeta honetan ezin da mota honetako elementurik kargatu."
 
@@ -171,56 +171,63 @@ msgstr "Karpeta honetan ezin da mota honetako elementurik kargatu."
 msgid "Upload"
 msgstr "Kargatu"
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr "Bideo fitxategiak"
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr "Ez duzu elementu-mota hau sortzeko baimenik"
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr "Aukeratu fitxategiak aukeratzeaz bat kargatzen hasi nahi baduzu formularioa bidali gabe. Aukeratuta badago ezin dituzu fitxategiak izenburu eta deskribapenak bete."
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr "Aukeratuta badago fitxategien deskribapenak kargatu aurretik bete ditzakezu. Ez aukeratu deskribapenak behar ez badituzu."
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr "Aukeratuta badago fitxategien izenburuak kargatu aurretik bete ditzakezu. Ez aukeratu izenburuak behar ez badituzu."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr ""
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr ""
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr "Aukeratu \"Fitxategiak kargatu\" akzio bat edizio-barran edukitzeko. Klik egindakoan fitxategiak kargatzeko leiho bat agertuko da. Aukera hau portleta erabiltzearen ordezko formula da eta ez du beste konfiguraziorik. "
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr "Aldi berean kargatu ahal den fitxategi kopurua, zenbaki horretatik gora fitxategiak kolan geratuko dira, 0 jarriz gero ez dago mugarik."
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr "Fitxategien tamaina maximoa KBtan, 0 = mugarik ez"
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
+#, fuzzy
 msgid "description_use_flash_fallback"
 msgstr "Aukeratu Internet Explorer nabigatzailean flash formatuko kargatzailea erabili nahi baduzu"
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
+#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Defektuz kargatzeko lana javascript tresna batek egiten du. Aukeratu kutxa hau Flash formatuko kargatzaile bat erabiltzeko. Nabigatzaile berrietan javascript tresna hobea da. Flash formatukoa nabigatzaile zaharretan egokiagoa da (hala nola IE7 edo IE8), baina hainbat arazo ditu: ez dabil https-rekin, ez dabil HTTP autentikazioarekin, ..."
 
@@ -240,13 +247,13 @@ msgid "label_clear_queue"
 msgstr "Kola hustu"
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr "Defektuzko konfigurazioa (Content Type Registry)"
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr "${medialabel} Karga Azkarra"
 
@@ -255,65 +262,70 @@ msgstr "${medialabel} Karga Azkarra"
 msgid "label_upload_files"
 msgstr "Fitxategiak kargatu"
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr "fitxategiaren gehienezko tamaina:"
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr "${filename} fitxategia ordezkatu egin da"
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr "aukeratu berriz fitxategiak hori gabe."
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr "saiatu berriz mesedez."
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr "Aukeratzerakoan automatikoki kargatu"
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr "Kargatu aurretik deskribapena bete"
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr "Kargatu aurretik izenburuak bete"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr ""
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr ""
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr "Erakutsi \"Kargatu\" akzioa"
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr "Batera kargatuko diren fitxategi-kopurua"
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr "Tamaina-muga"
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr "Erabili flash Internet Explorer-en"
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr "Flash kargatzailea erabili"
 

--- a/collective/quickupload/locales/fi/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/fi/LC_MESSAGES/collective.quickupload.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-25 09:49+0000\n"
+"POT-Creation-Date: 2015-09-28 06:47+0000\n"
 "PO-Revision-Date: 2012-10-31 20:47+0200\n"
 "Last-Translator: Petri Savolainen <petri.savolainen@koodaamo.fi>\n"
 "Language-Team: SUOMEKSI <LL@li.org>\n"
@@ -230,7 +230,6 @@ msgstr ""
 
 #. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
 #: ../browser/quickupload_settings.py:18
-#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Ruksaa tämä jos haluat käyttää Flash-teknologiaa Javascript:in sijaan. Sitä ei suositella, mutta vanhoissa MS IE-selaimissa (IE6, IE7) se voi tarjota paremman käyttäjäkokemuksen."
 

--- a/collective/quickupload/locales/fi/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/fi/LC_MESSAGES/collective.quickupload.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: 2012-10-31 20:47+0200\n"
 "Last-Translator: Petri Savolainen <petri.savolainen@koodaamo.fi>\n"
 "Language-Team: SUOMEKSI <LL@li.org>\n"
@@ -19,27 +19,27 @@ msgstr ""
 "X-Poedit-Language: Finnish\n"
 "X-Poedit-Country: FINLAND\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr "tiedostot onnistuneesti tuotu,"
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr "siirtotoiminto tuotti virheen."
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr "Tietokannassa tapahtui yhteiskäyttövirhe tuotaessa tiedostoa:"
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr "Kaikki"
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr "Kaikki tiedostot tuotu."
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr "Äänitiedostot"
 
@@ -47,91 +47,91 @@ msgstr "Äänitiedostot"
 msgid "Batch upload files."
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr "Otsikko"
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr "Selaa"
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr "Valitse tuotavat äänitiedostot"
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr "Valitse tuotava tiedosto: ${ext}"
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr "Valitse tuotavat Flash-tiedostot"
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr "Valitse tuotavat kuvatiedostot"
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr "Valitse tuotava mediatyyppi: kuvat, ääni- tai videotiedostot, jne."
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr "Aseta tarvittaessa tuotavien tiedostojen sisältötyyppi. Muussa tapauksessa käytetyt sisältötyypit valitaan järjestelmän sisältötyyppirekisterin määritysten mukaisesti."
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr "Valitse tuotavat videotiedostot"
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr "Tiedostotyyppi"
 
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr "Määritä tiedostojen tuontityökalun käyttöasetukset."
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr "Vedä ja pudota tähän"
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr "Epäonnistui"
 
 msgid "Files"
 msgstr ""
 
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr "Tiedostojen tuonti"
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr "Flash-tiedostot"
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr "Jos otsikko jätetään tyhjäksi, otsikoksi asetetaan oletusotsikko."
 
 msgid "Image"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr "Kuvat"
 
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr "Kuvien tuonti"
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr "Tiedostojen tyyppi"
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr "Sallitut:"
 
@@ -139,35 +139,35 @@ msgstr "Sallitut:"
 msgid "Quick Upload"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr "Tuontityökalun asetukset"
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr "Valinta sisältää kansioita tai tyhjiä tiedostoja:"
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr "Palvelinvirhe, ole hyvä ja ota yhteyttä tukipalveluun tai yritä uudelleen."
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr "Samanniminen tiedosto on jo tuotu."
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr "Tiedoston pääte ei ole sallittu:"
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr "Tiedostolla ei ole päätettä:"
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr "Tiedosto on liian iso:"
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr "Tämän tyyppinen tiedosto ei ole sallittu tässä kohteessa."
 
@@ -175,56 +175,62 @@ msgstr "Tämän tyyppinen tiedosto ei ole sallittu tässä kohteessa."
 msgid "Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr "Videotiedostot"
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr "Oikeutesi eivät riitä sisällön lisäämiseen."
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr "Ruksaa jos haluat tiedostojen siirron alkavan heti kun ne on valittu. Huomaa, että tällöin et voi antaa tiedstoille otsakkeita tai kuvauksia."
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr "Ruksaa jos haluat antaa tuotaville tiedostoille kuvaukset. Jätä tyhjäksi jos et tarvitse kuvauksia."
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr "Ruksaa, jos haluat antaa tiedostoille otsikot. Jätä ruksaamatta jos et tarvitse otsikoita kuville."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr ""
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr ""
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr ""
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr "Yhtaikaisten tiedostosiirtojen enimmäismäärä (lukumäärän ylittävät tiedostot asetetaan siirtojonoon), 0 = rajoittamaton"
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr "Tiedostojen enimmäiskoko kilotavuissa (KB), 0 = rajoittamaton"
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
 msgid "description_use_flash_fallback"
 msgstr ""
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
+#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Ruksaa tämä jos haluat käyttää Flash-teknologiaa Javascript:in sijaan. Sitä ei suositella, mutta vanhoissa MS IE-selaimissa (IE6, IE7) se voi tarjota paremman käyttäjäkokemuksen."
 
@@ -244,13 +250,13 @@ msgid "label_clear_queue"
 msgstr "Peru siirto"
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr "Oletuskonfiguraatio (Content Type Registry)"
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr "${medialabel} pikalataus"
 
@@ -259,65 +265,70 @@ msgstr "${medialabel} pikalataus"
 msgid "label_upload_files"
 msgstr "Lataa tiedostot"
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr "enimmäiskoko on:"
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr "Tiedosto ${filename} on korvattu"
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr "ole hyvä ja valitse tiedostot uudelleen ilman sitä."
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr "ole hyvä, yritä uudestaan."
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr "Tuonti alkaa välittömästi"
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr "Täytä kuvaus ennen tuontia"
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr "Täytä otsikko ennen tuontia"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr ""
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr ""
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr ""
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr "Yhtäikaisia siirtoja"
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr "Enimmäiskoko"
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr ""
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr "Käytä Flash-vaihtoehtoa"
 

--- a/collective/quickupload/locales/fi/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/fi/LC_MESSAGES/collective.quickupload.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: 2012-10-31 20:47+0200\n"
 "Last-Translator: Petri Savolainen <petri.savolainen@koodaamo.fi>\n"
 "Language-Team: SUOMEKSI <LL@li.org>\n"
@@ -87,7 +87,7 @@ msgstr "Valitse tuotavat videotiedostot"
 msgid "Content type"
 msgstr "Tiedostotyyppi"
 
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr "Määritä tiedostojen tuontityökalun käyttöasetukset."
 
@@ -139,7 +139,7 @@ msgstr "Sallitut:"
 msgid "Quick Upload"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr "Tuontityökalun asetukset"
 
@@ -199,11 +199,11 @@ msgid "description_fill_titles"
 msgstr "Ruksaa, jos haluat antaa tiedostoille otsikot. Jätä ruksaamatta jos et tarvitse otsikoita kuville."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr ""
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
 msgstr ""
@@ -298,11 +298,11 @@ msgid "title_fill_titles"
 msgstr "Täytä otsikko ennen tuontia"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr ""
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
 msgid "title_object_unique_id"
 msgstr ""

--- a/collective/quickupload/locales/fr/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/fr/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: 2014-01-25 22:15+0100\n"
 "Last-Translator: Thomas Desvenain <thomasdesvenain@ecreall.com>\n"
 "Language-Team: \n"
@@ -86,7 +86,7 @@ msgid "Content type"
 msgstr "Type de contenu"
 
 #. Default: "Control how the quick upload tool is used."
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr "Contrôlez comment l'outil d'envoi rapide de fichiers est utilisé."
 
@@ -141,7 +141,7 @@ msgid "Quick Upload"
 msgstr "Quick Upload"
 
 #. Default: "Quick Upload settings"
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr "Configuration de Quick Upload"
 
@@ -201,11 +201,11 @@ msgid "description_fill_titles"
 msgstr "Si sélectionné, vous pouvez saisir les titres de fichiers avant leur envoi. Décochez, si vous n'avez pas besoin de titres."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr "Si un fichier du même nom existe déjà dans le dossier. Si cette case est cochée : il est écrasé. Si la case n'est pas cochée : le téléversement n'aboutit pas."
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
 msgstr ""
@@ -301,11 +301,11 @@ msgid "title_fill_titles"
 msgstr "Saisir les titres avant l'envoi"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr "Écraser les fichiers existants au téléversement"
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
 msgid "title_object_unique_id"
 msgstr ""

--- a/collective/quickupload/locales/fr/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/fr/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-25 09:49+0000\n"
+"POT-Creation-Date: 2015-09-28 06:47+0000\n"
 "PO-Revision-Date: 2014-01-25 22:15+0100\n"
 "Last-Translator: Thomas Desvenain <thomasdesvenain@ecreall.com>\n"
 "Language-Team: \n"
@@ -227,13 +227,11 @@ msgstr "Taille limite de chaque fichier en KB, 0 = pas de limite"
 
 #. Default: "Check if you want to use flash uload as fallback for IE"
 #: ../browser/quickupload_settings.py:33
-#, fuzzy
 msgid "description_use_flash_fallback"
 msgstr "Cochez cette case si vous souhaitez utiliser flash upload pour IE"
 
 #. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
 #: ../browser/quickupload_settings.py:18
-#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Par défaut, le script d'envoi de fichiers est en pur javascript. Sélectionner cette option pour le remplacer par un script basé sur Flash Upload. Pour les navigateurs modernes l'outil en javascript est plus puissant. Flash Upload est seulement plus facile d'emploi sur les autres navigateurs (MSIE 7, MSIE 8), mais présente de nombreux inconvénients : ne marche pas en https, ne marche pas derrière une authentification HTTP ..."
 

--- a/collective/quickupload/locales/fr/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/fr/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: 2014-01-25 22:15+0100\n"
 "Last-Translator: Thomas Desvenain <thomasdesvenain@ecreall.com>\n"
 "Language-Team: \n"
@@ -17,27 +17,27 @@ msgstr ""
 "X-Is-Fallback-For: fr-be fr-ca fr-lu fr-mc fr-ch fr-fr\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr " fichiers téléversés avec succès, "
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr " téléversements ont échoué."
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr "Un conflit sur la base de données est survenu pendant le téléversement de ce fichier :"
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr "Tous"
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr "Tous les fichiers ont été téléversés avec succès."
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr "Fichiers audio"
 
@@ -45,56 +45,56 @@ msgstr "Fichiers audio"
 msgid "Batch upload files."
 msgstr "Paginer les fichiers téléversés"
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr "Titre de la boîte"
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr "Parcourir"
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr "Choisissez les fichiers audio à téléverser"
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr "Choisissez les fichiers à téléverser : ${ext}"
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr "Choisissez les fichiers flash à téléverser"
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr "Choisissez les images à téléverser"
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr "Choisir le type de média utilisé pour l'envoi de fichiers.  image, audio, vidéo ..."
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr "Choisir le type de contenu utilisé pour l'envoi de fichiers. Laisser la configuration par défaut pour que le type soit choisi automatiquement en fonction des paramètres définis dans content_type_registry."
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr "Choisissez les vidéos à téléverser"
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr "Type de contenu"
 
 #. Default: "Control how the quick upload tool is used."
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr "Contrôlez comment l'outil d'envoi rapide de fichiers est utilisé."
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr "Glissez-déposez les fichiers à téléverser"
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr "Echec"
 
@@ -102,37 +102,37 @@ msgid "Files"
 msgstr "Fichiers"
 
 #. Default: "Files Quick Upload"
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr "Envoi Rapide de Fichiers"
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr "Fichiers Flash"
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr "Si le titre est absent, le titre de la boîte sera 'Téléversement rapide de ' + Choix du Média."
 
 msgid "Image"
 msgstr "Images"
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr "Images"
 
 #. Default: "Images Quick Upload"
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr "Envoi Rapide d'Images"
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr "Type de média"
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr "Seulement autorisé :"
 
@@ -141,35 +141,35 @@ msgid "Quick Upload"
 msgstr "Quick Upload"
 
 #. Default: "Quick Upload settings"
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr "Configuration de Quick Upload"
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr "Les éléments sélectionnés contiennent un fichier vide ou un dossier :"
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr "Erreur serveur, veuillez réessayer ou contacter votre administrateur."
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr "Le dossier contient déjà un fichier de ce nom :"
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr "Ce fichier a une extension invalide :"
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr "Ce fichier n'a pas d'extension :"
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr "Ce fichier est trop gros :"
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr "Ce type d'élément n'est pas autorisé dans ce dossier."
 
@@ -177,56 +177,63 @@ msgstr "Ce type d'élément n'est pas autorisé dans ce dossier."
 msgid "Upload"
 msgstr "Téléverser"
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr "Fichiers vidéo"
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr "Vous n'avez pas la permission d'ajouter ce contenu à cet endroit."
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr "Sélectionner si vous voulez démarrer l'envoi de fichiers dés la sélection, sans avoir à soumettre le formulaire. Notez que vous ne pouvez pas choisir les titres ou descriptions de fichiers avec cette option sélectionnée."
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr "Si sélectionné, vous pouvez saisir les descriptions de fichiers avant leur envoi. Décochez, si vous n'avez pas besoin de descriptions."
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr "Si sélectionné, vous pouvez saisir les titres de fichiers avant leur envoi. Décochez, si vous n'avez pas besoin de titres."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr "Si un fichier du même nom existe déjà dans le dossier. Si cette case est cochée : il est écrasé. Si la case n'est pas cochée : le téléversement n'aboutit pas."
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr ""
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr "Cochez cette case si vous souhaitez avoir un lien \"Téléverser\" dans votre barre d'édition. Un clic ouvrira un panneau de téléversement sous le titre. Ce panneau est une alternative à la portlet et ne sera proposé que si la portlet n'est pas présente."
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr "Nombre d'envois de fichiers envoyés simultanément, au delà de ce nombre les fichiers sont placés en file d'attente, 0 = pas de limite"
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr "Taille limite de chaque fichier en KB, 0 = pas de limite"
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
+#, fuzzy
 msgid "description_use_flash_fallback"
 msgstr "Cochez cette case si vous souhaitez utiliser flash upload pour IE"
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
+#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Par défaut, le script d'envoi de fichiers est en pur javascript. Sélectionner cette option pour le remplacer par un script basé sur Flash Upload. Pour les navigateurs modernes l'outil en javascript est plus puissant. Flash Upload est seulement plus facile d'emploi sur les autres navigateurs (MSIE 7, MSIE 8), mais présente de nombreux inconvénients : ne marche pas en https, ne marche pas derrière une authentification HTTP ..."
 
@@ -246,13 +253,13 @@ msgid "label_clear_queue"
 msgstr "Annuler"
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr "Configuration par défaut (Content Type Registry)"
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr "Téléverser des ${medialabel}"
 
@@ -261,65 +268,70 @@ msgstr "Téléverser des ${medialabel}"
 msgid "label_upload_files"
 msgstr "Envoyer fichiers"
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr "la taille maximum d'un fichier est :"
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr "Le fichier ${filename} a été remplacé"
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr "veuillez sélectionner de nouveau les fichiers sans celui-ci"
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr "veuillez essayer à nouveau"
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr "Envoi direct sur sélection"
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr "Saisir les descriptions avant l'envoi"
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr "Saisir les titres avant l'envoi"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr "Écraser les fichiers existants au téléversement"
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr ""
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr "Afficher l'action \"Téléverser\""
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr "Envois simultanés maximum"
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr "Taille limite"
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr "Utiliser flash comme fallback pour IE"
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr "Utiliser Flash Upload"
 

--- a/collective/quickupload/locales/it/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/it/LC_MESSAGES/collective.quickupload.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: 2012-09-24 14:22+0200\n"
 "Last-Translator: Giacomo Spettoli <giacomo.spettoli@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
@@ -86,7 +86,7 @@ msgstr "Scegli i file video da caricare"
 msgid "Content type"
 msgstr "Tipo di contenuto"
 
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr "Controlla come il tool quick upload viene utilizzato."
 
@@ -138,7 +138,7 @@ msgstr "Permessi solamente:"
 msgid "Quick Upload"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr "Impostazioni di Quick Upload"
 
@@ -198,11 +198,11 @@ msgid "description_fill_titles"
 msgstr "Se selezionata, sarà possibile inserire i titoli dei file prima del caricamento. Deselezionare se non si necessita dei titoli."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr ""
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
 msgstr ""
@@ -297,11 +297,11 @@ msgid "title_fill_titles"
 msgstr "Inserire il titolo prima di caricare"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr ""
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
 msgid "title_object_unique_id"
 msgstr ""

--- a/collective/quickupload/locales/it/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/it/LC_MESSAGES/collective.quickupload.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-25 09:49+0000\n"
+"POT-Creation-Date: 2015-09-28 06:47+0000\n"
 "PO-Revision-Date: 2012-09-24 14:22+0200\n"
 "Last-Translator: Giacomo Spettoli <giacomo.spettoli@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
@@ -229,7 +229,6 @@ msgstr ""
 
 #. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
 #: ../browser/quickupload_settings.py:18
-#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Di default, lo script di upload è uno strumento di solo javascript. Seleziona questa opzione per sostituirlo con uno script Flash. Per i browser moderni il javascript è più potente. Il caricamento Flash è più semplice per l'utente di altri browser (MSIE 7, MSIE 8), ma ha molti problemi : non supporta l'https, non funziona dietro a una autenticazione HTTP, etc."
 

--- a/collective/quickupload/locales/it/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/it/LC_MESSAGES/collective.quickupload.po
@@ -1,10 +1,10 @@
 # Translation of collective.quickupload.pot to Italian
 # Giacomo Spettoli <giacomo.spettoli@gmail.com>, 2011.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: 2012-09-24 14:22+0200\n"
 "Last-Translator: Giacomo Spettoli <giacomo.spettoli@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
@@ -18,27 +18,27 @@ msgstr ""
 "Domain: collective.quickupload\n"
 "X-Is-Fallback-For: it-ch it-it\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr "file caricati con successo, "
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr " caricamenti restituiscono un errore."
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr "Si è verificato un conflitto sul database durante il caricamento di questo file:"
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr "Tutto"
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr "Tutti i file sono stati caricati con successo."
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr "Files audio"
 
@@ -46,91 +46,91 @@ msgstr "Files audio"
 msgid "Batch upload files."
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr "Titolo del box"
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr "Sfoglia"
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr "Scegli i file audio da caricare"
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr "Scegli il file da caricare: ${ext}"
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr "Scegli i file flash da caricare"
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr "Scegli le immagini da caricare"
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr "Scegli il tipo di media utilizzato per caricare il file. immagine, audio, video ..."
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr "Scegli il tipo di contenuto usato per il caricamento dei file. Lasciare la configurazione predefinita per un tipo di contenuto automatico, in base alle impostazioni definite in content_type_registry."
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr "Scegli i file video da caricare"
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr "Tipo di contenuto"
 
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr "Controlla come il tool quick upload viene utilizzato."
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr "Trascina e rilascia qui i file per caricarli"
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr "Fallito"
 
 msgid "Files"
 msgstr ""
 
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr "Quick upload dei file"
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr "I file flash"
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr "Se il titolo è vuoto, il titolo della portlet sarà Media Choice + ' Quick Upload'."
 
 msgid "Image"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr "Immagini"
 
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr "Quick upload di immagini"
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr "Tipo di Media"
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr "Permessi solamente:"
 
@@ -138,35 +138,35 @@ msgstr "Permessi solamente:"
 msgid "Quick Upload"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr "Impostazioni di Quick Upload"
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr "Gli elementi selezionati contengono file vuoti o una cartella:"
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr "Errore del server, prego contattare il supporto e/o provare nuovamente."
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr "Questo file esiste già con lo stesso nome sul server:"
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr "Questo file ha un'estensione non valida:"
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr "Questo file non ha estensione:"
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr "Questo file è troppo grande:"
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr "Non è permesso aggiungere questo tipo di contenuto in questa cartella."
 
@@ -174,56 +174,62 @@ msgstr "Non è permesso aggiungere questo tipo di contenuto in questa cartella."
 msgid "Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr "Files video"
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr "Non si dispone dei permessi per aggiungere questo contenuto in questa posizione."
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr "Seleziona per iniziare il caricamento automaticamente appena i file vengono selezionati, senza inviare il form. Notare che non sarà possibile scegliere i titoli o le descrizioni con questa opzione abilitata"
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr "Se selezionata, sarà possibile inserire le descrizioni dei file prima del caricamento. Deselezionare se non si necessita delle descrizioni."
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr "Se selezionata, sarà possibile inserire i titoli dei file prima del caricamento. Deselezionare se non si necessita dei titoli."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr ""
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr ""
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr ""
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr "Numero di caricamenti di file simultanei, i caricamenti sopra questo numero verranno messi in coda, 0 = nessun limite"
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr "Dimesione massima per ogni file in KB, 0 = nessun limite"
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
 msgid "description_use_flash_fallback"
 msgstr ""
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
+#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Di default, lo script di upload è uno strumento di solo javascript. Seleziona questa opzione per sostituirlo con uno script Flash. Per i browser moderni il javascript è più potente. Il caricamento Flash è più semplice per l'utente di altri browser (MSIE 7, MSIE 8), ma ha molti problemi : non supporta l'https, non funziona dietro a una autenticazione HTTP, etc."
 
@@ -243,13 +249,13 @@ msgid "label_clear_queue"
 msgstr "Svuota la coda"
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr "Configurazione predefinita (Registro dei tipi di contenuto)."
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr "${medialabel} Quick Upload"
 
@@ -258,65 +264,70 @@ msgstr "${medialabel} Quick Upload"
 msgid "label_upload_files"
 msgstr "Carica i file"
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr "la dimesione massima dei file è:"
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr "Il file ${filename} è stato sostituito"
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr "selezionare i file nuovamente senza di esso."
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr "prego, riprovare."
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr "Caricamento automatico alla selezione"
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr "Inserire la descrizione prima di caricare"
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr "Inserire il titolo prima di caricare"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr ""
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr ""
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr ""
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr "Limite di caricamenti simultanei"
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr "Limite di dimensione"
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr ""
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr "Utilizza il caricamento Flash"
 

--- a/collective/quickupload/locales/nl/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/nl/LC_MESSAGES/collective.quickupload.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-25 09:49+0000\n"
+"POT-Creation-Date: 2015-09-28 06:47+0000\n"
 "PO-Revision-Date: 2011-08-31 12:10+0000’\n"
 "Last-Translator: Maarten Kling <maarten@fourdigits.nl>\n"
 "Language-Team: Dutch <support@fourdigits.nl>\n"

--- a/collective/quickupload/locales/nl/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/nl/LC_MESSAGES/collective.quickupload.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: 2011-08-31 12:10+0000’\n"
 "Last-Translator: Maarten Kling <maarten@fourdigits.nl>\n"
 "Language-Team: Dutch <support@fourdigits.nl>\n"
@@ -82,7 +82,7 @@ msgstr "Kies video bestanden om te uploaden"
 msgid "Content type"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr "Hoe de quick upload tool wordt gebruikt."
 
@@ -134,7 +134,7 @@ msgstr "Alleen toegestaan:"
 msgid "Quick Upload"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr ""
 
@@ -194,11 +194,11 @@ msgid "description_fill_titles"
 msgstr ""
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr ""
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
 msgstr ""
@@ -292,11 +292,11 @@ msgid "title_fill_titles"
 msgstr "Plaats titels voor uploaden"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr ""
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
 msgid "title_object_unique_id"
 msgstr ""

--- a/collective/quickupload/locales/nl/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/nl/LC_MESSAGES/collective.quickupload.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: 2011-08-31 12:10+0000’\n"
 "Last-Translator: Maarten Kling <maarten@fourdigits.nl>\n"
 "Language-Team: Dutch <support@fourdigits.nl>\n"
@@ -14,27 +14,27 @@ msgstr ""
 "Preferred-Encodings: utf-8\n"
 "Domain: collective.quickupload\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr " bestanden met succes geupload, "
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr " upload gaf een foutmelding."
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr "Een data base conflict foutmelding tijdens uploaden van het bestand:"
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr "Alle"
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr "Alle bestanden met succes geupload"
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr "Audio bestanden"
 
@@ -42,91 +42,91 @@ msgstr "Audio bestanden"
 msgid "Batch upload files."
 msgstr "Batch upload bestanden"
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr "Box titel"
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr "Browse"
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr "Kies audio bestanden om te uploaden"
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr "Kies een bestand te uploaden: ${ext}"
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr "Kies flash bestanden om te uploaden"
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr "Kies afbeeldingen om te uploaden"
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr "Kies een media type om te uploaden. afbeelding, audio, video ..."
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr ""
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr "Kies video bestanden om te uploaden"
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr "Hoe de quick upload tool wordt gebruikt."
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr "Sleep bestanden hier om te uploaden"
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr "Gefaald"
 
 msgid "Files"
 msgstr ""
 
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr "Als de titel leeg is, zal de portlet ' Quick Upload' heten."
 
 msgid "Image"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr "Afbeeldingen"
 
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr "Afbeeldingen Quick Upload"
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr ""
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr "Alleen toegestaan:"
 
@@ -134,35 +134,35 @@ msgstr "Alleen toegestaan:"
 msgid "Quick Upload"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr ""
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr "Geselecteerde elementen zijn leeg of een map:"
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr "Server error, probeer het nog eens."
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr "Dit bestand bestaad reeds op de server met dezefde naam:"
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr "Dit bestand heeft een foute extensie:"
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr "Dit bestand heeft geen extensie:"
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr "Dit bestand is te groot:"
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr "Dit type is niet toegestaan in deze map."
 
@@ -170,56 +170,61 @@ msgstr "Dit type is niet toegestaan in deze map."
 msgid "Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr "Video bestanden"
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr ""
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr ""
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr ""
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr ""
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr ""
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr ""
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr ""
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr ""
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr ""
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
 msgid "description_use_flash_fallback"
 msgstr ""
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
 msgid "description_use_flashupload"
 msgstr ""
 
@@ -239,13 +244,13 @@ msgid "label_clear_queue"
 msgstr "Leeg Queue"
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr ""
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr ""
 
@@ -254,65 +259,70 @@ msgstr ""
 msgid "label_upload_files"
 msgstr "Upload bestanden"
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr "maximale formaat is:"
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr "${filename} bestand is hernoemd"
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr "selecteer bestanden nogmaals, zonder het."
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr "probeer het nog eens."
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr "Automatisch uploaden bij selectie"
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr "Vul beschrijving voor uploaden"
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr "Plaats titels voor uploaden"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr ""
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr ""
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr "Toon \"Upload\" actie"
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr "Gelijktijdig upload limiet"
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr "Size limiet"
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr "Gebruik Flash upload voor IE"
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr "Gebruik Flash Upload"
 

--- a/collective/quickupload/locales/no/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/no/LC_MESSAGES/collective.quickupload.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: 2011-08-31 12:10+0000’\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Tormod Mansåker <tormod@jarn.com>\n"
@@ -14,27 +14,27 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr "vellykket opplasting av filer,"
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr ""
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr "Det oppstod en database konflikt når denne filen ble forsøkt opplastet:"
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr "Alle"
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr "Alle filene ble lastet opp."
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr "Lydfiler"
 
@@ -42,91 +42,91 @@ msgstr "Lydfiler"
 msgid "Batch upload files."
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr ""
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr "Bla gjennom"
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr "Velg lydfiler som skal lastes opp"
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr "Velg filer som skal lastes opp: ${ext}"
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr "Velg flash filer som skal lastes opp"
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr "Velg bilder som skal lastes opp"
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr "Velg filtype for opplasting. Image, lyd, video ..."
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr ""
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr "Velg video filer som skal lastes opp"
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr "Innholdstype"
 
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr "Kontrollerer hvordan filopplastingsverktøyet blir brukt"
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr "Dra og slipp filer til opplasting"
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr "Feil"
 
 msgid "Files"
 msgstr ""
 
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr "Flash filer"
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr ""
 
 msgid "Image"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr "Bilder"
 
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr ""
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr "Kun tillatt"
 
@@ -134,35 +134,35 @@ msgstr "Kun tillatt"
 msgid "Quick Upload"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr ""
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr "Valgte elementer inneholder en top fil eller mappe:"
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr "Server feil, vennligst kontakt support og/eller prøv igjen."
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr "Denne filen finnes allerede med samme navn på serveren:"
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr "Denne filen har ikke tillatt type angivelse:"
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr ""
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr "Denne filen er for stor:"
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr ""
 
@@ -170,56 +170,61 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr "Videofiler"
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr "Du har ikke rettigheter til å legge til innhold på dette stedet."
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr ""
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr ""
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr ""
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr ""
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr ""
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr ""
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr ""
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr ""
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
 msgid "description_use_flash_fallback"
 msgstr ""
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
 msgid "description_use_flashupload"
 msgstr ""
 
@@ -239,13 +244,13 @@ msgid "label_clear_queue"
 msgstr ""
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr ""
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr ""
 
@@ -254,65 +259,70 @@ msgstr ""
 msgid "label_upload_files"
 msgstr ""
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr "maksimum filstørrelse er:"
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr ""
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr "vennligst velg filer igjen uten den."
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr "vennligst prøv igjen."
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr ""
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr "Fyll ut beskrivelse feltet før opplasting"
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr ""
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr ""
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr ""
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr ""
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr ""
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr ""
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr ""
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr ""
 

--- a/collective/quickupload/locales/no/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/no/LC_MESSAGES/collective.quickupload.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-25 09:49+0000\n"
+"POT-Creation-Date: 2015-09-28 06:47+0000\n"
 "PO-Revision-Date: 2011-08-31 12:10+0000’\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Tormod Mansåker <tormod@jarn.com>\n"

--- a/collective/quickupload/locales/no/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/no/LC_MESSAGES/collective.quickupload.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: 2011-08-31 12:10+0000’\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Tormod Mansåker <tormod@jarn.com>\n"
@@ -82,7 +82,7 @@ msgstr "Velg video filer som skal lastes opp"
 msgid "Content type"
 msgstr "Innholdstype"
 
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr "Kontrollerer hvordan filopplastingsverktøyet blir brukt"
 
@@ -134,7 +134,7 @@ msgstr "Kun tillatt"
 msgid "Quick Upload"
 msgstr ""
 
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr ""
 
@@ -194,11 +194,11 @@ msgid "description_fill_titles"
 msgstr ""
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr ""
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
 msgstr ""
@@ -292,11 +292,11 @@ msgid "title_fill_titles"
 msgstr ""
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr ""
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
 msgid "title_object_unique_id"
 msgstr ""

--- a/collective/quickupload/locales/pt_BR/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/pt_BR/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-25 09:49+0000\n"
+"POT-Creation-Date: 2015-09-28 06:47+0000\n"
 "PO-Revision-Date: 2011-06-16 12:39-0300\n"
 "Last-Translator: Erico Andrei <erico@simplesconsultoria.com.br>\n"
 "Language-Team: Simples Consultoria <contato@simplesconsultoria.com.br>\n"
@@ -230,7 +230,6 @@ msgstr ""
 
 #. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
 #: ../browser/quickupload_settings.py:18
-#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Por padrão o script de envio usado utiliza apenas javascript. Selecione esta opção para trocá-lo por uma ferramenta de envio que utiliza a tecnologia Flash. Para navegadores modernos a ferramenta javascript é mais poderosa. A ferramenta em Flash é mais amigável para navegadores antigos (MSIE 7 e MSIE 8), mas apresenta vários limitantes: Não suporta https nem autenticação HTTP..."
 

--- a/collective/quickupload/locales/pt_BR/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/pt_BR/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: 2011-06-16 12:39-0300\n"
 "Last-Translator: Erico Andrei <erico@simplesconsultoria.com.br>\n"
 "Language-Team: Simples Consultoria <contato@simplesconsultoria.com.br>\n"
@@ -84,7 +84,7 @@ msgid "Content type"
 msgstr "Tipo de conteúdo"
 
 #. Default: "Control how the quick upload tool is used."
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr "Controle como o envio rápido de arquivos é utilizado."
 
@@ -139,7 +139,7 @@ msgid "Quick Upload"
 msgstr ""
 
 #. Default: "Quick Upload settings"
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr "Configurações do envio rápido"
 
@@ -199,11 +199,11 @@ msgid "description_fill_titles"
 msgstr "Caso selecionado, você poderá informar os títulos dos arquivos antes do envio. Caso não precise dos títulos, não selecione esta opção."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr ""
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
 msgstr ""
@@ -298,11 +298,11 @@ msgid "title_fill_titles"
 msgstr "Preencha os títulos antes do envio"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr ""
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
 msgid "title_object_unique_id"
 msgstr ""

--- a/collective/quickupload/locales/pt_BR/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/pt_BR/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: 2011-06-16 12:39-0300\n"
 "Last-Translator: Erico Andrei <erico@simplesconsultoria.com.br>\n"
 "Language-Team: Simples Consultoria <contato@simplesconsultoria.com.br>\n"
@@ -15,27 +15,27 @@ msgstr ""
 "Preferred-Encodings: utf-8\n"
 "Domain: collective.quickupload\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr " arquivos enviados com sucesso, "
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr " envios retornaram erros."
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr "Um conflito de base de dados ocorreu durante o envio deste arquivo:"
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr "Todos"
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr "Todos os arquivos enviados com sucesso."
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr "Arquivos de áudio"
 
@@ -43,56 +43,56 @@ msgstr "Arquivos de áudio"
 msgid "Batch upload files."
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr "Título do portlet"
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr "Procurar"
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr "Escolha os arquivos de áudio a serem enviados"
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr "Escolha arquivos para envio: ${ext}"
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr "Escolha arquivos flash para envio"
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr "Escolha imagens para envio"
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr "Escolha o tipo de mídia utilizado para o envio dos arquivos. Imagem, áudio, vídeo..."
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr "Selecione o tipo de conteúdo utilizado para o envio dos arquivos. A configuração padrão detecta o tipo de conteúdo dependendo das informações existentes no content_type_registry"
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr "Escolha os arquivos de vídeo para envio"
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr "Tipo de conteúdo"
 
 #. Default: "Control how the quick upload tool is used."
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr "Controle como o envio rápido de arquivos é utilizado."
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr "Clique e arraste os arquivos a serem enviados"
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr "Falhou"
 
@@ -100,37 +100,37 @@ msgid "Files"
 msgstr ""
 
 #. Default: "Files Quick Upload"
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr "Envio rápido de arquivos"
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr "Arquivos Flash"
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr "Caso o título seja deixado em branco, o título do portlet será o Tipo de mídia + Envio Rápido de Arquivos"
 
 msgid "Image"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr "Imagens"
 
 #. Default: "Images Quick Upload"
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr "Envio rápido de imagens"
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr "Tipo de mídia"
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr "Permitido apenas:"
 
@@ -139,35 +139,35 @@ msgid "Quick Upload"
 msgstr ""
 
 #. Default: "Quick Upload settings"
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr "Configurações do envio rápido"
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr "Os elementos selecionados contém arquivos vazios ou uma pasta:"
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr "Erro do servidor, por favor contate o suporte ou tente novamente."
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr "Um arquivo com o mesmo nome existe no servidor:"
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr "Este arquivo tem uma extensão inválida:"
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr ""
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr "Este arquivo é muito grande:"
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr ""
 
@@ -175,56 +175,62 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr "Arquivos de vídeo"
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr "Você não tem permissão para adicionar conteúdos neste local."
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr "Clique aqui caso queira que o envio dos arquivos ocorra automaticamente, sem o envio do formulário. Importante lembrar que você não poderá editar o título ou descrição destes arquivos antes do envio caso esta opção esteja ativada."
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr "Quando selecionado, você poderá informar as descrições para os arquivos antes do envio. Não selecione caso as descrições não sejam necessárias. "
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr "Caso selecionado, você poderá informar os títulos dos arquivos antes do envio. Caso não precise dos títulos, não selecione esta opção."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr ""
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr ""
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr ""
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr "Número de arquivos enviados simultaneamente, acima deste limite os envios serão enfileirados. 0 = sem limite"
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr "Limite do envio para cada arquivo em KB, 0 = sem limite"
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
 msgid "description_use_flash_fallback"
 msgstr ""
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
+#, fuzzy
 msgid "description_use_flashupload"
 msgstr "Por padrão o script de envio usado utiliza apenas javascript. Selecione esta opção para trocá-lo por uma ferramenta de envio que utiliza a tecnologia Flash. Para navegadores modernos a ferramenta javascript é mais poderosa. A ferramenta em Flash é mais amigável para navegadores antigos (MSIE 7 e MSIE 8), mas apresenta vários limitantes: Não suporta https nem autenticação HTTP..."
 
@@ -244,13 +250,13 @@ msgid "label_clear_queue"
 msgstr "Limpar fila"
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr ""
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr "Envio rápido de ${medialabel}"
 
@@ -259,65 +265,70 @@ msgstr "Envio rápido de ${medialabel}"
 msgid "label_upload_files"
 msgstr "Upload de arquivos"
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr "tamanho máximo do arquivo é:"
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr ""
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr "por favor selecione os arquivos novamente sem ele."
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr "por favor, tente novamente."
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr "Envio automático após a seleção"
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr "Preencha as descrições antes do envio."
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr "Preencha os títulos antes do envio"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr ""
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr ""
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr ""
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr "Limite de envio de arquivos simultâneos"
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr "Limite de envio"
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr ""
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr "Utilizar o upload com Flash"
 

--- a/collective/quickupload/locales/sk/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/sk/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-25 09:49+0000\n"
+"POT-Creation-Date: 2015-09-28 06:47+0000\n"
 "PO-Revision-Date: 2012-12-22 14:23+0100\n"
 "Last-Translator: Roman Lacko <backup.rlacko@gmail.com>\n"
 "Language-Team: \n"
@@ -230,7 +230,6 @@ msgstr ""
 
 #. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
 #: ../browser/quickupload_settings.py:18
-#, fuzzy
 msgid "description_use_flashupload"
 msgstr "V predvolenom nastavení, skript na prevzatie je len javascript. Zaškrtnite túto voľbu, aby ste ho nahradili flashom. Pre moderné prehliadače je javascript vhodnejší. Flash je prívetivejšie pre niektoré prehliadače (MSIE 7, MSIE 8), ale má mnoho problémov: nefunguje v https ani s HTTP autentikáciou ..."
 

--- a/collective/quickupload/locales/sk/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/sk/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: 2012-12-22 14:23+0100\n"
 "Last-Translator: Roman Lacko <backup.rlacko@gmail.com>\n"
 "Language-Team: \n"
@@ -15,27 +15,27 @@ msgstr ""
 "Preferred-Encodings: utf-8\n"
 "Domain: collective.quickupload\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr " súbory úspešne prevzaté, "
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr " prevzatie skončené s chybou"
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr "Nastal konflikt počas prevzatia tohto súboru:"
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr "Všetko"
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr "Všetky súbory úspešne prevzaté."
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr "Audio súbory"
 
@@ -43,56 +43,56 @@ msgstr "Audio súbory"
 msgid "Batch upload files."
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr "Názov"
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr "Vybrať"
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr "Zvoliť audio súbory."
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr "Zvoliť súbory na prevzatie: ${ext}"
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr "Zvoliť flash súbory"
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr "Zvoliť obrázky."
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr "Zvoliť typ média, ktorý bude použitý počas prevzatia súborov. obrázok, audio, video ..."
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr "Zvoliť portálový typ, ktorý bude použitý počas prevzatia súborov. Ponechať východzie nastavenie pre autonatický výber portálového typu."
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr "Zvoliť video súbory"
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr "Typ obsahu"
 
 #. Default: "Control how the quick upload tool is used."
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr "Nastaviť používanie pomôcky quick upload."
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr "Vložiť súbory na prevzatie"
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr "Chyba"
 
@@ -100,37 +100,37 @@ msgid "Files"
 msgstr ""
 
 #. Default: "Files Quick Upload"
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr "Súbory Quick Upload"
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr "Flash súbory"
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr "Ak názov je prázdny, názov portletu bude Typ média + ' Quick Upload'."
 
 msgid "Image"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr "Obrázky"
 
 #. Default: "Images Quick Upload"
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr "Obrázky Quick Upload"
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr "Typ média"
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr "Povolené iba:"
 
@@ -139,35 +139,35 @@ msgid "Quick Upload"
 msgstr ""
 
 #. Default: "Quick Upload settings"
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr "Nastavenia pre Quick Upload"
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr "Vybrané elementy obsahujú prázdne súbory alebo adresáre:"
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr "Chyba servera, prosím kontaktujte podporu a/alebo zopakujte prevzatie."
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr "Tento súbor už existuje s rovnakým menom na serveri:"
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr "Tento súbor má neznámu príponu:"
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr "Tento súbor nemá žiadnu príponu:"
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr "Tento súbor je príliš veľký:"
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr "Tento typ elementu nie je povolený v tejto zložke."
 
@@ -175,56 +175,62 @@ msgstr "Tento typ elementu nie je povolený v tejto zložke."
 msgid "Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr "Video súbory"
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr "Nemáte oprávnenie pridať tento objekt na toto miesto."
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr "Potvrdťe ak chcete začať prevzatie súborov hned po ich výbere. Povolením tejto možnosťi však nebudete môcť zadať meno a popis súboru."
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr "Povolením tejto možnosťi budete môcť zadať popis súborov ešte pred ich prevzatím. Zrušte ak nepotrebujete zadať popis."
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr "Povolením tejto možnosťi budete môcť zadať meno súborov ešte pred ich prevzatím. Zrušte ak nepotrebujete zadať meno."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr ""
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr ""
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr ""
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr "Počet súčasne prevzatých súborov, súbory nad tento počet sú umiestnené do fronty, 0 = bez limitu"
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr "Limit veľkosti pre každý súbor v KB, 0 = žiadny limit"
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
 msgid "description_use_flash_fallback"
 msgstr ""
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
+#, fuzzy
 msgid "description_use_flashupload"
 msgstr "V predvolenom nastavení, skript na prevzatie je len javascript. Zaškrtnite túto voľbu, aby ste ho nahradili flashom. Pre moderné prehliadače je javascript vhodnejší. Flash je prívetivejšie pre niektoré prehliadače (MSIE 7, MSIE 8), ale má mnoho problémov: nefunguje v https ani s HTTP autentikáciou ..."
 
@@ -244,13 +250,13 @@ msgid "label_clear_queue"
 msgstr "Vyčistiť frontu"
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr "Predvolená konfigurácia (Content Type Registry)."
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr "${medialabel} Quick Upload"
 
@@ -259,65 +265,70 @@ msgstr "${medialabel} Quick Upload"
 msgid "label_upload_files"
 msgstr "Prevziať súbory"
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr "maximálna veľkosť súboru je:"
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr "Súbor ${filename} bol nahradený"
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr "prosím vyberte súbory ešte raz bez neho."
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr "skúste to znova prosím."
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr "Autoatické prevzatie po výbere"
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr "Zadať popis pred prevzatím"
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr "Zadať meno pred prevzatím"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr ""
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr ""
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr ""
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr "Maximálny počet simultánne prevzatých súborov"
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr "Maximálna veľkosť"
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr ""
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr "Použiť flash k prevzatiu"
 

--- a/collective/quickupload/locales/sk/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/sk/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: 2012-12-22 14:23+0100\n"
 "Last-Translator: Roman Lacko <backup.rlacko@gmail.com>\n"
 "Language-Team: \n"
@@ -84,7 +84,7 @@ msgid "Content type"
 msgstr "Typ obsahu"
 
 #. Default: "Control how the quick upload tool is used."
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr "Nastaviť používanie pomôcky quick upload."
 
@@ -139,7 +139,7 @@ msgid "Quick Upload"
 msgstr ""
 
 #. Default: "Quick Upload settings"
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr "Nastavenia pre Quick Upload"
 
@@ -199,11 +199,11 @@ msgid "description_fill_titles"
 msgstr "Povolením tejto možnosťi budete môcť zadať meno súborov ešte pred ich prevzatím. Zrušte ak nepotrebujete zadať meno."
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr ""
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
 msgstr ""
@@ -298,11 +298,11 @@ msgid "title_fill_titles"
 msgstr "Zadať meno pred prevzatím"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr ""
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
 msgid "title_object_unique_id"
 msgstr ""

--- a/collective/quickupload/locales/zh_CN/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/zh_CN/LC_MESSAGES/collective.quickupload.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: 2012-05-16 07:19+0800\n"
 "Last-Translator: Jian Aijun <jianaijun@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sf.net>\n"
@@ -85,7 +85,7 @@ msgid "Content type"
 msgstr "内容类型"
 
 #. Default: "Control how the quick upload tool is used."
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr "控制如何使用快速上传工具。"
 
@@ -140,7 +140,7 @@ msgid "Quick Upload"
 msgstr ""
 
 #. Default: "Quick Upload settings"
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr "快速上传设置"
 
@@ -200,11 +200,11 @@ msgid "description_fill_titles"
 msgstr "如果选中，上传前您可以填写文件的标题。"
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr ""
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
 msgstr ""
@@ -299,11 +299,11 @@ msgid "title_fill_titles"
 msgstr "上传前填写标题"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr ""
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
 msgid "title_object_unique_id"
 msgstr ""

--- a/collective/quickupload/locales/zh_CN/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/zh_CN/LC_MESSAGES/collective.quickupload.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-25 09:49+0000\n"
+"POT-Creation-Date: 2015-09-28 06:47+0000\n"
 "PO-Revision-Date: 2012-05-16 07:19+0800\n"
 "Last-Translator: Jian Aijun <jianaijun@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sf.net>\n"
@@ -231,7 +231,6 @@ msgstr ""
 
 #. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
 #: ../browser/quickupload_settings.py:18
-#, fuzzy
 msgid "description_use_flashupload"
 msgstr "默认情况下，系统使用 JavaScript 处理上传。如果选中，会改用 FLASH 来上传。现代的浏览器都提供功能强大的 JavaScript。 而 Flash 上传方式，并非所有浏览器都支持，并且还有很多问题，例如：不支持 HTTPS，不支持 HTTPS 认证方式 ..."
 

--- a/collective/quickupload/locales/zh_CN/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/zh_CN/LC_MESSAGES/collective.quickupload.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: 2012-05-16 07:19+0800\n"
 "Last-Translator: Jian Aijun <jianaijun@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sf.net>\n"
@@ -16,27 +16,27 @@ msgstr ""
 "Preferred-Encodings: utf-8\n"
 "Domain: collective.quickupload\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr " 已成功上传，"
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr " 上传返回一个错误。"
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr "上传这个文件时，数据库发生冲突："
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr "全部"
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr "所有文件上传成功。"
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr "音频文件"
 
@@ -44,56 +44,56 @@ msgstr "音频文件"
 msgid "Batch upload files."
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr "面板标题"
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr "浏览"
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr "选择要上传的音频文件"
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr "选择上传的文件：${ext}"
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr "选择要上传的 Flash 文件"
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr "选择要上传的图片文件"
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr "选择想要上传的媒体类型。图片，音频，视频 ..."
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr "选择上传文件使用的网站内容类型，使用默认配置，系统会根据内容类型注册表的设置自动处理。"
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr "选择要上传的视频文件"
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr "内容类型"
 
 #. Default: "Control how the quick upload tool is used."
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr "控制如何使用快速上传工具。"
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr "拖放文件上传"
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr "失败"
 
@@ -101,37 +101,37 @@ msgid "Files"
 msgstr ""
 
 #. Default: "Files Quick Upload"
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr "文件快速上传"
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr "Flash 文件"
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr "如果标题为空，面板标题将是 ‘媒体类型‘ + 快速上传。"
 
 msgid "Image"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr "图片"
 
 #. Default: "Images Quick Upload"
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr "图片快速上传"
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr "媒体类型"
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr "只允许："
 
@@ -140,35 +140,35 @@ msgid "Quick Upload"
 msgstr ""
 
 #. Default: "Quick Upload settings"
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr "快速上传设置"
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr "选择的元素包含一个空文件或文件夹："
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr "服务器错误，请联系支持或重试。"
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr "在服务器上已存在与此文件同名的文件："
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr "此文件的扩展名无效："
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr ""
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr "此文件太大："
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr ""
 
@@ -176,56 +176,62 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr "视频文件"
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr "您没有在这个地方添加内容的权限。"
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr "如果选中，选择文件后会自动上传，不需进一步确认。请注意，这种方式您无法事先填写文件标题或描述。"
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr "如果选中，上传前您可以填写文件的描述。"
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr "如果选中，上传前您可以填写文件的标题。"
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr ""
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr ""
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr ""
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr "同时上传的文件数量，超过这个数量将放置在队列中，0 代表沒有限制。"
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr "每个文件的大小限制，单位：KB，0 代表沒有限制。"
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
 msgid "description_use_flash_fallback"
 msgstr ""
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
+#, fuzzy
 msgid "description_use_flashupload"
 msgstr "默认情况下，系统使用 JavaScript 处理上传。如果选中，会改用 FLASH 来上传。现代的浏览器都提供功能强大的 JavaScript。 而 Flash 上传方式，并非所有浏览器都支持，并且还有很多问题，例如：不支持 HTTPS，不支持 HTTPS 认证方式 ..."
 
@@ -245,13 +251,13 @@ msgid "label_clear_queue"
 msgstr "清除队列"
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr ""
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr "${medialabel} 快速上传"
 
@@ -260,65 +266,70 @@ msgstr "${medialabel} 快速上传"
 msgid "label_upload_files"
 msgstr "上传文件"
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr "最大文件大小是："
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr "文件 ${filename} 已被替换"
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr "请在再次选择文件时取消它。"
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr "请重试。"
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr "选择后自动上传"
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr "上传前填写描述"
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr "上传前填写标题"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr ""
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr ""
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr ""
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr "同时上传限制"
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr "大小限制"
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr ""
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr "使用 Flash 上​​传"
 

--- a/collective/quickupload/locales/zh_TW/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/zh_TW/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-24 11:05+0000\n"
+"POT-Creation-Date: 2015-09-25 09:49+0000\n"
 "PO-Revision-Date: 2015-03-06 11:10+0800\n"
 "Last-Translator: TsungWei Hu <marr.tw@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
@@ -84,7 +84,7 @@ msgid "Content type"
 msgstr "內容型別"
 
 #. Default: "Control how the quick upload tool is used."
-#: ../browser/quickupload_settings.py:227
+#: ../browser/quickupload_settings.py:229
 msgid "Control how the quick upload tool is used."
 msgstr "設定批次上傳工具的操作方式。"
 
@@ -139,7 +139,7 @@ msgid "Quick Upload"
 msgstr ""
 
 #. Default: "Quick Upload settings"
-#: ../browser/quickupload_settings.py:226
+#: ../browser/quickupload_settings.py:228
 msgid "Quick Upload settings"
 msgstr "批次上傳設定"
 
@@ -199,11 +199,11 @@ msgid "description_fill_titles"
 msgstr "勾選的話，上傳之前可以事先填寫標題。"
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:123
+#: ../browser/quickupload_settings.py:125
 msgid "description_object_override"
 msgstr "勾選的話，相同檔名的檔案，會被上傳的檔案所覆蓋；不勾選的話，則會產生上傳錯誤。"
 
-#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique. The 'Override by upload file' option is considered when a conflict happens."
 #: ../browser/quickupload_settings.py:111
 msgid "description_object_unique_id"
 msgstr ""
@@ -299,11 +299,11 @@ msgid "title_fill_titles"
 msgstr "上傳之前填寫標題"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:122
+#: ../browser/quickupload_settings.py:124
 msgid "title_object_override"
 msgstr "上傳檔案會覆蓋舊檔案"
 
-#. Default: "Choose unique id"
+#. Default: "Choose unique file id"
 #: ../browser/quickupload_settings.py:110
 msgid "title_object_unique_id"
 msgstr ""

--- a/collective/quickupload/locales/zh_TW/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/zh_TW/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2014-01-25 21:26+0000\n"
+"POT-Creation-Date: 2015-09-24 11:05+0000\n"
 "PO-Revision-Date: 2015-03-06 11:10+0800\n"
 "Last-Translator: TsungWei Hu <marr.tw@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
@@ -15,27 +15,27 @@ msgstr ""
 "Preferred-Encodings: utf-8\n"
 "Domain: collective.quickupload\n"
 
-#: ../browser/quick_upload.py:464
+#: ../browser/quick_upload.py:474
 msgid " files uploaded with success, "
 msgstr " 個檔案上傳成功，"
 
-#: ../browser/quick_upload.py:465
+#: ../browser/quick_upload.py:475
 msgid " uploads return an error."
 msgstr " 個檔案上傳失敗。"
 
-#: ../browser/quick_upload.py:478
+#: ../browser/quick_upload.py:488
 msgid "A data base conflict error happened when uploading this file:"
 msgstr "上傳這個檔案的時候，發生資料庫衝突："
 
-#: ../portlet/quickuploadportlet.py:95
+#: ../portlet/quickuploadportlet.py:100
 msgid "All"
 msgstr "全部"
 
-#: ../browser/quick_upload.py:463
+#: ../browser/quick_upload.py:473
 msgid "All files uploaded with success."
 msgstr "全部檔案上傳成功。"
 
-#: ../portlet/quickuploadportlet.py:98
+#: ../portlet/quickuploadportlet.py:103
 msgid "Audio files"
 msgstr "聲音檔"
 
@@ -43,56 +43,56 @@ msgstr "聲音檔"
 msgid "Batch upload files."
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:76
+#: ../portlet/quickuploadportlet.py:77
 msgid "Box title"
 msgstr "方框標題"
 
-#: ../browser/quick_upload.py:461
+#: ../browser/quick_upload.py:471
 msgid "Browse"
 msgstr "瀏覽"
 
-#: ../browser/quick_upload.py:407
+#: ../browser/quick_upload.py:414
 msgid "Choose audio files to upload"
 msgstr "選擇聲音檔來上傳"
 
-#: ../browser/quick_upload.py:415
+#: ../browser/quick_upload.py:422
 msgid "Choose file for upload: ${ext}"
 msgstr "選擇檔案來上傳： ${ext}"
 
-#: ../browser/quick_upload.py:410
+#: ../browser/quick_upload.py:417
 msgid "Choose flash files to upload"
 msgstr "選擇 Flash 檔案來上傳"
 
-#: ../browser/quick_upload.py:401
+#: ../browser/quick_upload.py:408
 msgid "Choose images to upload"
 msgstr "選擇圖檔來上傳"
 
-#: ../portlet/quickuploadportlet.py:91
+#: ../portlet/quickuploadportlet.py:95
 msgid "Choose the media type used for file upload. image, audio, video ..."
 msgstr "選擇想要上傳的媒體類型，像是圖檔、聲音檔、影片檔。"
 
-#: ../portlet/quickuploadportlet.py:83
+#: ../portlet/quickuploadportlet.py:85
 msgid "Choose the portal type used for file upload. Let the default configuration for an automatic portal type, depending on settings defined in content_type_registry."
 msgstr "選擇想要上傳的內容型別，使用預設值的話，系統會依照型別註冊的結果自動處理。"
 
-#: ../browser/quick_upload.py:404
+#: ../browser/quick_upload.py:411
 msgid "Choose video files to upload"
 msgstr "選擇影片檔來上傳"
 
-#: ../portlet/quickuploadportlet.py:82
+#: ../portlet/quickuploadportlet.py:84
 msgid "Content type"
 msgstr "內容型別"
 
 #. Default: "Control how the quick upload tool is used."
-#: ../browser/quickupload_settings.py:170
+#: ../browser/quickupload_settings.py:227
 msgid "Control how the quick upload tool is used."
 msgstr "設定批次上傳工具的操作方式。"
 
-#: ../browser/quick_upload.py:462
+#: ../browser/quick_upload.py:472
 msgid "Drag and drop files to upload"
 msgstr "拖拉檔案來上傳"
 
-#: ../browser/quick_upload.py:466
+#: ../browser/quick_upload.py:476
 msgid "Failed"
 msgstr "失敗"
 
@@ -100,37 +100,37 @@ msgid "Files"
 msgstr ""
 
 #. Default: "Files Quick Upload"
-#: ../browser/quick_upload.py:200
-#: ../portlet/quickuploadportlet.py:123
+#: ../browser/quick_upload.py:202
+#: ../portlet/quickuploadportlet.py:130
 msgid "Files Quick Upload"
 msgstr "檔案批次上傳"
 
-#: ../portlet/quickuploadportlet.py:99
+#: ../portlet/quickuploadportlet.py:104
 msgid "Flash files"
 msgstr "Flash 檔"
 
-#: ../portlet/quickuploadportlet.py:78
+#: ../portlet/quickuploadportlet.py:79
 msgid "If title is empty, the portlet title will be the Media Choice + ' Quick Upload'."
 msgstr "標題空白的話，會配合型別自動指定標題。"
 
 msgid "Image"
 msgstr ""
 
-#: ../portlet/quickuploadportlet.py:96
+#: ../portlet/quickuploadportlet.py:101
 msgid "Images"
 msgstr "圖檔"
 
 #. Default: "Images Quick Upload"
-#: ../browser/quick_upload.py:202
-#: ../portlet/quickuploadportlet.py:125
+#: ../browser/quick_upload.py:204
+#: ../portlet/quickuploadportlet.py:132
 msgid "Images Quick Upload"
 msgstr "圖檔批次上傳"
 
-#: ../portlet/quickuploadportlet.py:90
+#: ../portlet/quickuploadportlet.py:94
 msgid "Media type"
 msgstr "媒體類型"
 
-#: ../browser/quick_upload.py:474
+#: ../browser/quick_upload.py:484
 msgid "Only allowed:"
 msgstr "只允許："
 
@@ -139,35 +139,35 @@ msgid "Quick Upload"
 msgstr ""
 
 #. Default: "Quick Upload settings"
-#: ../browser/quickupload_settings.py:169
+#: ../browser/quickupload_settings.py:226
 msgid "Quick Upload settings"
 msgstr "批次上傳設定"
 
-#: ../browser/quick_upload.py:469
+#: ../browser/quick_upload.py:479
 msgid "Selected elements contain an empty file or a folder:"
 msgstr "選擇的項目裡包含空檔或目錄："
 
-#: ../browser/quick_upload.py:479
+#: ../browser/quick_upload.py:489
 msgid "Server error, please contact support and/or try again."
 msgstr "請檢查目錄裡是否已存在這個檔名的檔案，或是聯絡管理人員。"
 
-#: ../browser/quick_upload.py:477
+#: ../browser/quick_upload.py:487
 msgid "This file already exists with the same name on server:"
 msgstr "這個檔案已經存在："
 
-#: ../browser/quick_upload.py:473
+#: ../browser/quick_upload.py:483
 msgid "This file has invalid extension:"
 msgstr "這個檔案存在錯誤的延伸檔名："
 
-#: ../browser/quick_upload.py:470
+#: ../browser/quick_upload.py:480
 msgid "This file has no extension:"
 msgstr "這個檔案沒有延伸檔名："
 
-#: ../browser/quick_upload.py:471
+#: ../browser/quick_upload.py:481
 msgid "This file is too large:"
 msgstr "這個檔案大小超過限制："
 
-#: ../browser/quick_upload.py:476
+#: ../browser/quick_upload.py:486
 msgid "This type of element is not allowed in this folder."
 msgstr "這個目錄不允許這類檔案。"
 
@@ -175,56 +175,63 @@ msgstr "這個目錄不允許這類檔案。"
 msgid "Upload"
 msgstr "上傳"
 
-#: ../portlet/quickuploadportlet.py:97
+#: ../portlet/quickuploadportlet.py:102
 msgid "Video files"
 msgstr "影片檔"
 
-#: ../browser/quick_upload.py:475
+#: ../browser/quick_upload.py:485
 msgid "You don't have permission to add this content in this place."
 msgstr "沒有權限在目錄裡新增這個項目。"
 
 #. Default: "Check if you want to start the files upload on select, without submit the form. Note that you cannot choose file titles or descriptions with this option set to True."
-#: ../browser/quickupload_settings.py:35
+#: ../browser/quickupload_settings.py:42
 msgid "description_auto_upload"
 msgstr "勾選的話，選完檔案之後就會自動上傳，而不需要確認送出。這種上傳方式，無法事先填寫標題或描述。"
 
 #. Default: "If checked, you can fill the files descriptions before upload. Uncheck if you don't need descriptions."
-#: ../browser/quickupload_settings.py:61
+#: ../browser/quickupload_settings.py:79
 msgid "description_fill_descriptions"
 msgstr "勾選的話，上傳之前可以事先填寫描述。"
 
 #. Default: "If checked, you can fill the files titles before upload. Uncheck if you don't need titles."
-#: ../browser/quickupload_settings.py:55
+#: ../browser/quickupload_settings.py:68
 msgid "description_fill_titles"
 msgstr "勾選的話，上傳之前可以事先填寫標題。"
 
 #. Default: "If the folder already has same file name, Checked: Override, Non-Checked: raise upload error."
-#: ../browser/quickupload_settings.py:77
+#: ../browser/quickupload_settings.py:123
 msgid "description_object_override"
 msgstr "勾選的話，相同檔名的檔案，會被上傳的檔案所覆蓋；不勾選的話，則會產生上傳錯誤。"
 
+#. Default: "Choose a unique id for each uploaded file.Checked: Your files will never be overridden and you'll never get a 'file already exists' error message because each file has its unique id.Non-Checked: The id will not be unique."
+#: ../browser/quickupload_settings.py:111
+msgid "description_object_unique_id"
+msgstr ""
+
 #. Default: "Check if you want to have an \"Upload\" link in your edit bar. Clicking it will open a panel for uploading below the title of the current item. This panel is an alternative to the \"Upload\" portlet and does not offer any further configuration, such as filtering by content type. The panel will only be shown where the \"Upload\" portlet is not present."
-#: ../browser/quickupload_settings.py:42
+#: ../browser/quickupload_settings.py:53
 msgid "description_show_upload_action"
 msgstr "勾選的話，在編輯列會顯示「上傳」頁籤，點選後會顯示上傳的功能頁面。"
 
 #. Default: "Number of simultaneous files uploaded, over this number uploads are placed in a queue, 0 = no limit"
-#: ../browser/quickupload_settings.py:72
+#: ../browser/quickupload_settings.py:101
 msgid "description_sim_upload_limit"
 msgstr "指定同時上傳的檔案數目，超過數目的檔案會排隊再上傳，0 代表沒有限制。"
 
 #. Default: "Size limit for each file in KB, 0 = no limit"
-#: ../browser/quickupload_settings.py:67
+#: ../browser/quickupload_settings.py:88
 msgid "description_size_limit"
 msgstr "以 KB 設定檔案大小的上限，0 代表沒有限制。"
 
-#. Default: "Check if you want to use flash upload as fallback for IE"
-#: ../browser/quickupload_settings.py:28
+#. Default: "Check if you want to use flash uload as fallback for IE"
+#: ../browser/quickupload_settings.py:33
+#, fuzzy
 msgid "description_use_flash_fallback"
 msgstr "勾選的話，對舊版 IE 瀏覽器會改用 Flash 來支援上傳功能。"
 
-#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8),  but has many problems : don't work in https, don't work behind HTTP Authentication ..."
-#: ../browser/quickupload_settings.py:17
+#. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
+#: ../browser/quickupload_settings.py:18
+#, fuzzy
 msgid "description_use_flashupload"
 msgstr "系統預設使用 JavaScript 處理上傳，勾選的話，會改用 Flash 來上傳。多數的瀏覽器都支援 JavaScript，但 Flash 上傳方式並非支援所有瀏覽器，例如不支援 HTTPS 或 HTTP 認證等。"
 
@@ -244,13 +251,13 @@ msgid "label_clear_queue"
 msgstr "全部取消"
 
 #. Default: "Default configuration (Content Type Registry)."
-#: ../portlet/vocabularies.py:53
+#: ../portlet/vocabularies.py:49
 msgid "label_default_portaltype_configuration"
 msgstr "預設功能"
 
 #. Default: "${medialabel} Quick Upload"
-#: ../browser/quick_upload.py:204
-#: ../portlet/quickuploadportlet.py:127
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
 msgid "label_media_quickupload"
 msgstr "${medialabel} 上傳檔案"
 
@@ -259,65 +266,70 @@ msgstr "${medialabel} 上傳檔案"
 msgid "label_upload_files"
 msgstr "上傳檔案"
 
-#: ../browser/quick_upload.py:472
+#: ../browser/quick_upload.py:482
 msgid "maximum file size is:"
 msgstr "檔案大小限制是："
 
 #. Default: "${filename} file has been replaced"
-#: ../browser/uploadcapable.py:160
+#: ../browser/uploadcapable.py:170
 msgid "msg_file_replaced"
 msgstr "${filename} 個檔案被覆蓋更新"
 
-#: ../browser/quick_upload.py:467
+#: ../browser/quick_upload.py:477
 msgid "please select files again without it."
 msgstr "請不要選擇它，並重新上傳一次。"
 
-#: ../browser/quick_upload.py:468
+#: ../browser/quick_upload.py:478
 msgid "please try again."
 msgstr "請再試一次。"
 
 #. Default: "Automatic upload on select"
-#: ../browser/quickupload_settings.py:34
+#: ../browser/quickupload_settings.py:41
 msgid "title_auto_upload"
 msgstr "選檔之後自動上傳"
 
 #. Default: "Fill description before upload"
-#: ../browser/quickupload_settings.py:60
+#: ../browser/quickupload_settings.py:76
 msgid "title_fill_descriptions"
 msgstr "上傳之前填寫描述"
 
 #. Default: "Fill title before upload"
-#: ../browser/quickupload_settings.py:54
+#: ../browser/quickupload_settings.py:67
 msgid "title_fill_titles"
 msgstr "上傳之前填寫標題"
 
 #. Default: "Override by upload file"
-#: ../browser/quickupload_settings.py:76
+#: ../browser/quickupload_settings.py:122
 msgid "title_object_override"
 msgstr "上傳檔案會覆蓋舊檔案"
 
+#. Default: "Choose unique id"
+#: ../browser/quickupload_settings.py:110
+msgid "title_object_unique_id"
+msgstr ""
+
 #. Default: "Show \"Upload\" action"
-#: ../browser/quickupload_settings.py:41
+#: ../browser/quickupload_settings.py:52
 msgid "title_show_upload_action"
 msgstr "顯示「上傳」頁籤"
 
 #. Default: "Simultaneous uploads limit"
-#: ../browser/quickupload_settings.py:71
+#: ../browser/quickupload_settings.py:97
 msgid "title_sim_upload_limit"
 msgstr "同時上傳的上限"
 
 #. Default: "Size limit"
-#: ../browser/quickupload_settings.py:66
+#: ../browser/quickupload_settings.py:87
 msgid "title_size_limit"
 msgstr "檔案大小的上限"
 
 #. Default: "Use flash as fallback for IE"
-#: ../browser/quickupload_settings.py:25
+#: ../browser/quickupload_settings.py:31
 msgid "title_use_flash_fallback"
 msgstr "改用 Flash 上傳"
 
 #. Default: "Use Flash Upload"
-#: ../browser/quickupload_settings.py:16
+#: ../browser/quickupload_settings.py:17
 msgid "title_use_flashupload"
 msgstr "使用 Flash 上傳"
 

--- a/collective/quickupload/locales/zh_TW/LC_MESSAGES/collective.quickupload.po
+++ b/collective/quickupload/locales/zh_TW/LC_MESSAGES/collective.quickupload.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.quickupload\n"
-"POT-Creation-Date: 2015-09-25 09:49+0000\n"
+"POT-Creation-Date: 2015-09-28 06:47+0000\n"
 "PO-Revision-Date: 2015-03-06 11:10+0800\n"
 "Last-Translator: TsungWei Hu <marr.tw@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
@@ -225,13 +225,11 @@ msgstr "以 KB 設定檔案大小的上限，0 代表沒有限制。"
 
 #. Default: "Check if you want to use flash uload as fallback for IE"
 #: ../browser/quickupload_settings.py:33
-#, fuzzy
 msgid "description_use_flash_fallback"
 msgstr "勾選的話，對舊版 IE 瀏覽器會改用 Flash 來支援上傳功能。"
 
 #. Default: "By default, the upload script is a javascript only tool. Check this option to replace it with a Flash Upload based script. For modern browsers the javascript tool is more powerful. Flash Upload is just more user friendly under other browsers (MSIE 7, MSIE 8), but has many problems : don't work in https, don't work behind HTTP Authentication ..."
 #: ../browser/quickupload_settings.py:18
-#, fuzzy
 msgid "description_use_flashupload"
 msgstr "系統預設使用 JavaScript 處理上傳，勾選的話，會改用 Flash 來上傳。多數的瀏覽器都支援 JavaScript，但 Flash 上傳方式並非支援所有瀏覽器，例如不支援 HTTPS 或 HTTP 認證等。"
 

--- a/collective/quickupload/profiles/default/metadata.xml
+++ b/collective/quickupload/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>6</version>
+  <version>7</version>
 </metadata>

--- a/collective/quickupload/profiles/default/propertiestool.xml
+++ b/collective/quickupload/profiles/default/propertiestool.xml
@@ -10,6 +10,7 @@
   <property name="fill_descriptions" type="boolean">False</property>
   <property name="size_limit" type="int">0</property>
   <property name="sim_upload_limit" type="int">2</property>
+  <property name="object_unique_id" type="boolean">True</property>
   <property name="object_override" type="boolean">True</property>
  </object>
 </object>

--- a/collective/quickupload/tests/test_get_id_from_filename.py
+++ b/collective/quickupload/tests/test_get_id_from_filename.py
@@ -1,8 +1,13 @@
+from collective.quickupload.testing import QUICKUPLOAD_FUNCTIONAL_TESTING
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
 import mock
 import unittest2 as unittest
 
 
 class TestCase(unittest.TestCase):
+
+    layer = QUICKUPLOAD_FUNCTIONAL_TESTING
 
     def test_MissingExtension(self):
         from collective.quickupload.browser.uploadcapable import MissingExtension
@@ -18,3 +23,21 @@ class TestCase(unittest.TestCase):
             MissingExtension,
             lambda: get_id_from_filename(filename, context)
         )
+
+    def test_get_unique_filename(self):
+        filename = 'my-file.jpg'
+        portal = self.layer['portal']
+
+        # Set already existing file
+        setattr(portal, filename, object())
+
+        from collective.quickupload.browser.uploadcapable import get_id_from_filename
+
+        # Per default it does not return a unique value
+        self.assertEqual(
+            'my-file.jpg', get_id_from_filename(filename, portal))
+
+        # Otherwise it returns a unique id if the id already exists
+        self.assertEqual(
+            'my-file-1.jpg',
+            get_id_from_filename(filename, portal, unique=True))

--- a/collective/quickupload/upgrades/configure.zcml
+++ b/collective/quickupload/upgrades/configure.zcml
@@ -43,4 +43,12 @@
       handler=".upgrades.v5_v6"
       profile="collective.quickupload:default" />
 
+  <genericsetup:upgradeStep
+      title="Add object_unique_id property"
+      description=""
+      source="6"
+      destination="7"
+      handler=".upgrades.v6_v7"
+      profile="collective.quickupload:default" />
+
 </configure>

--- a/collective/quickupload/upgrades/upgrades.py
+++ b/collective/quickupload/upgrades/upgrades.py
@@ -42,3 +42,10 @@ def v5_v6(context):
     if not qu_props.hasProperty('object_override'):
         qu_props._setProperty('object_override', False, 'boolean')
 
+def v6_v7(context):
+    #Add property to quickupload property sheet
+    ptool = getToolByName(context, 'portal_properties')
+    qu_props = ptool.get('quickupload_properties')
+    if not qu_props.hasProperty('object_unique_id'):
+        qu_props._setProperty('object_unique_id', False, 'boolean')
+

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,12 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add property 'Choose unique file id'.
+  In addition to the 'Override by upload file' it is possible
+  to use unique file ids. The advantage of this is, that you
+  can upload files without overriding them and without an
+  error if the file already exists
+  [elioschmutz]
 
 
 1.7.0 (2015-07-28)

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -27,6 +27,9 @@ eggs =
 [versions]
 plone.app.testing = 4.2.2
 
+# Required by setuptools >= 0.6c11
+mock = 0.8.0
+
 # Required by plone.app.dexterity >= 2.0
 z3c.form = 3.0.0a3
 plone.app.z3cform = 0.7.2

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -20,5 +20,9 @@ eggs =
 
 [versions]
 
+# The lates version of plone isn't available in launchpad
+# https://launchpad.net/plone/4.2/4.2.7
+Plone = 4.2.6
+
 # Required by setuptools >= 0.6c11
 mock = 0.8.0

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -17,3 +17,8 @@ defaults = ['-s', '${buildout:package-name}', '--auto-color', '--auto-progress']
 eggs =
     ${buildout:package-name} ${buildout:package-extras}
     ${buildout:test-eggs}
+
+[versions]
+
+# Required by setuptools >= 0.6c11
+mock = 0.8.0

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -19,6 +19,11 @@ eggs =
     ${buildout:package-name} ${buildout:package-extras}
     ${buildout:test-eggs}
 
+# plone.app.testing now imports from Products.CMFPlacefulWorkflow, which
+# is often not installed because no explicity dependency is declared.
+# We now always install the Plone egg in order to have the full Plone stack ready.
+# https://github.com/plone/plone.app.upgrade/commit/b6a0f6e8865e94b53ff9f7f68385774fa7d5ab02
+    Plone
 
 [omelette]
 recipe = collective.recipe.omelette


### PR DESCRIPTION
@jone 

Add property `object_unique_id`.

In addition to the `object_override`-property, it is possible to use unique file ids. The advantage of this is, that you can upload files without overriding them and without an error if the file already exists

--
![bildschirmfoto 2015-09-24 um 13 24 47](https://cloud.githubusercontent.com/assets/557005/10072172/aa22db62-62bf-11e5-98df-ea67ba429f61.png)
--
![bildschirmfoto 2015-09-24 um 13 19 28](https://cloud.githubusercontent.com/assets/557005/10072067/0a19d940-62bf-11e5-8088-924382c38294.png)
--
![bildschirmfoto 2015-09-24 um 13 20 01](https://cloud.githubusercontent.com/assets/557005/10072068/0a1cdf3c-62bf-11e5-8718-17bac8fef0a7.png)
--


=> perhaps we can close this issue too: https://github.com/collective/collective.quickupload/issues/15
There is a big discussion how to solve this problem. But with the two properties= `object_unique_id`and `object_override`it is now possible to upload files with long filenames in two different ways...