### PR TITLE
set content type to application/json

### DIFF
--- a/collective/quickupload/browser/quick_upload.py
+++ b/collective/quickupload/browser/quick_upload.py
@@ -626,9 +626,9 @@ class QuickUploadFile(QuickUploadAuthenticate):
 
         response.setHeader('Expires', 'Sat, 1 Jan 2000 00:00:00 GMT')
         response.setHeader('Cache-control', 'no-cache')
-        # the good content type woul be text/json or text/plain but IE
-        # do not support it
-        response.setHeader('Content-Type', 'text/html; charset=utf-8')
+        # application/json is not supported by old IEs but text/html fails in every
+        # browser with plone.protect 3.0.11
+        response.setHeader('Content-Type', 'application/json; charset=utf-8')
         # disable diazo themes
         request.response.setHeader('X-Theme-Disabled', 'True')
 

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -10,6 +10,10 @@ Changelog
 - Added unittest2 to test requirements on Python 2.6.
   [maurits]
 
+- Set content type to application/json. text/html fails with plone.protect
+  3.0.11 (and is wrong anyway).
+  [reinhardt]
+
 
 1.8.0 (2015-09-30)
 ------------------


### PR DESCRIPTION
text/json is not supported by old IEs but text/html fails in every browser with plone.protect 3.0.11