### PR TITLE
Handle unittest2 dependency correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
+sudo: false
 language: python
 python:
   - 2.6
   - 2.7
+cache:
+  directories:
+  - eggs
 env:
   - PLONE_VERSION=4.1
   - PLONE_VERSION=4.2

--- a/collective/quickupload/tests/test_controlpanel.py
+++ b/collective/quickupload/tests/test_controlpanel.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
-
-import unittest2 as unittest
+try:
+    # Python 2.6
+    import unittest2 as unittest
+except ImportError:
+    # Python 2.7 has unittest2 integrated in unittest
+    import unittest
 
 from zope.component import getMultiAdapter
 

--- a/collective/quickupload/tests/test_dexterity_setter.py
+++ b/collective/quickupload/tests/test_dexterity_setter.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-import unittest2 as unittest
+try:
+    # Python 2.6
+    import unittest2 as unittest
+except ImportError:
+    # Python 2.7 has unittest2 integrated in unittest
+    import unittest
 
 from zope.interface import Interface
 from plone.app.testing import TEST_USER_ID

--- a/collective/quickupload/tests/test_doctest.py
+++ b/collective/quickupload/tests/test_doctest.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
+try:
+    # Python 2.6
+    import unittest2 as unittest
+except ImportError:
+    # Python 2.7 has unittest2 integrated in unittest
+    import unittest
 from plone.testing import layered
 from collective.quickupload import testing
 
 import doctest
-import unittest2 as unittest
 
 functional = [
     'installation.txt',

--- a/collective/quickupload/tests/test_get_id_from_filename.py
+++ b/collective/quickupload/tests/test_get_id_from_filename.py
@@ -1,8 +1,13 @@
+try:
+    # Python 2.6
+    import unittest2 as unittest
+except ImportError:
+    # Python 2.7 has unittest2 integrated in unittest
+    import unittest
 from collective.quickupload.testing import QUICKUPLOAD_FUNCTIONAL_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 import mock
-import unittest2 as unittest
 
 
 class TestCase(unittest.TestCase):

--- a/collective/quickupload/tests/test_mimetypes.py
+++ b/collective/quickupload/tests/test_mimetypes.py
@@ -1,4 +1,9 @@
-import unittest2 as unittest
+try:
+    # Python 2.6
+    import unittest2 as unittest
+except ImportError:
+    # Python 2.7 has unittest2 integrated in unittest
+    import unittest
 from collective.quickupload.testing import QUICKUPLOAD_INTEGRATION_TESTING
 import os.path
 from collective.quickupload.browser.quick_upload import get_content_type
@@ -9,7 +14,7 @@ import cgi
 class TestMimetypes(unittest.TestCase):
 
     layer = QUICKUPLOAD_INTEGRATION_TESTING
-    
+
     def setUp(self):
         self.portal = self.layer['portal']
         file_ = open("%s/testfile_mimetypes.txt" % os.path.split(__file__)[0], 'r')
@@ -21,7 +26,7 @@ class TestMimetypes(unittest.TestCase):
         mtr = getToolByName(self.portal, 'mimetypes_registry')
         mtr.manage_addMimeType('Only globs mimetype', ['application/x-only-glob'], [], 'application.png', globs=['*.onlyglob'])
         mtr.manage_addMimeType('Only extension mimetype', ['application/x-only-ext'], ['onlyext'], 'application.png')
-    
+
     def test_only_globs(self):
         content_type = get_content_type(self.portal, self.file_data, 'dummy.onlyglob')
         self.assertEqual('application/x-only-glob', content_type)
@@ -29,7 +34,7 @@ class TestMimetypes(unittest.TestCase):
     def test_only_ext(self):
         content_type = get_content_type(self.portal, self.file_data, 'dummy.onlyext')
         self.assertEqual('application/x-only-ext', content_type)
-    
+
     def test_recognized_by_python(self):
         content_type = get_content_type(self.portal, self.file_data, 'dummy.txt')
         self.assertEqual('text/plain', content_type)

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,8 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added unittest2 to test requirements on Python 2.6.
+  [maurits]
 
 
 1.8.0 (2015-09-30)

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,21 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 import os
+import sys
 
 
 def read(*paths):
     return open(os.path.join(os.path.dirname(__file__), *paths)).read()
 
 version = '1.8.1.dev0'
+
+tests_require = [
+    'plone.app.dexterity',
+    'plone.app.testing',
+    'mock',
+    ]
+if sys.version_info < (2, 7):
+    tests_require.append('unittest2')
 
 setup(name='collective.quickupload',
       version=version,
@@ -51,11 +60,7 @@ setup(name='collective.quickupload',
           'ua_parser',
       ],
       extras_require={
-          'test': [
-              'plone.app.dexterity',
-              'plone.app.testing',
-              'mock',
-          ],
+          'test': tests_require,
       },
       entry_points="""
       [z3c.autoinclude.plugin]


### PR DESCRIPTION
Travis should actually fail without this fix, but it does not: I guess Travis has unittest2 installed by default. Locally you get import errors on both 2.6 and 2.7 without this fix.

Also in this pull request: use container based infrastructure (sudo: false) on Travis to speed up builds.