### PR TITLE
New control panel option: id as title

### DIFF
--- a/collective/quickupload/browser/quick_upload.py
+++ b/collective/quickupload/browser/quick_upload.py
@@ -702,6 +702,8 @@ class QuickUploadFile(QuickUploadAuthenticate):
         portal_type = getDataFromAllRequests(request, 'typeupload') or ''
         title = getDataFromAllRequests(request, 'title') or ''
         description = getDataFromAllRequests(request, 'description') or ''
+        if not title.strip() and self.qup_prefs.id_as_title:
+            title = newid
 
         if not portal_type:
             ctr = getToolByName(context, 'content_type_registry')

--- a/collective/quickupload/browser/quickupload_settings.py
+++ b/collective/quickupload/browser/quickupload_settings.py
@@ -129,6 +129,18 @@ class IQuickUploadControlPanel(Interface):
         default=True,
         required=False)
 
+    id_as_title = Bool(
+        title=_(u"title_id_as_title", default=u"Use id as title"),
+        description=_(
+            u"description_id_as_title",
+            default=u"Reuse the file name for the title "
+                    u"when no explicit title is given. "
+                    u"Checked: use exact id including file extension, "
+                    u"Non-Checked: use cleaned id, without extension "
+                    u"and with spaces instead of dashes or underscores."),
+        default=False,
+        required=False)
+
 
 class QuickUploadControlPanelAdapter(SchemaAdapterBase):
 
@@ -221,6 +233,14 @@ class QuickUploadControlPanelAdapter(SchemaAdapterBase):
         self.quProps._updateProperty('object_override', value)
 
     object_override = property(get_object_override, set_object_override)
+
+    def get_id_as_title(self):
+        return self.quProps.getProperty('id_as_title')
+
+    def set_id_as_title(self, value):
+        self.quProps._updateProperty('id_as_title', value)
+
+    id_as_title = property(get_id_as_title, set_id_as_title)
 
 
 class QuickUploadControlPanel(ControlPanelForm):

--- a/collective/quickupload/profiles/default/metadata.xml
+++ b/collective/quickupload/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>7</version>
+  <version>8</version>
 </metadata>

--- a/collective/quickupload/profiles/default/propertiestool.xml
+++ b/collective/quickupload/profiles/default/propertiestool.xml
@@ -12,5 +12,6 @@
   <property name="sim_upload_limit" type="int">2</property>
   <property name="object_unique_id" type="boolean">True</property>
   <property name="object_override" type="boolean">True</property>
+  <property name="id_as_title" type="boolean">False</property>
  </object>
 </object>

--- a/collective/quickupload/tests/test_view.py
+++ b/collective/quickupload/tests/test_view.py
@@ -1,0 +1,153 @@
+try:
+    # Python 2.6
+    import unittest2 as unittest
+except ImportError:
+    # Python 2.7 has unittest2 integrated in unittest
+    import unittest
+from collective.quickupload.testing import QUICKUPLOAD_FUNCTIONAL_TESTING
+from zope.publisher.browser import TestRequest
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from StringIO import StringIO
+import json
+import transaction
+
+
+class TestCase(unittest.TestCase):
+
+    layer = QUICKUPLOAD_FUNCTIONAL_TESTING
+
+    def _upload_file(self, filename, title=None, description=None):
+        from collective.quickupload.browser.quick_upload import QuickUploadFile
+        portal = self.layer['portal']
+        request = TestRequest()
+        # We need a RESPONSE object.
+        request.RESPONSE = request._createResponse()
+        # Signal that this is an ajax upload:
+        request.HTTP_X_REQUESTED_WITH = 'XHR'
+        # Set file name:
+        request.HTTP_X_FILE_NAME = filename
+        request.BODYFILE = StringIO('dummy file content')
+        if title is not None:
+            request.form['title'] = title
+        if description is not None:
+            request.form['description'] = description
+        view = QuickUploadFile(portal, request)
+        return json.loads(view())
+
+    def test_upload_file_simple(self):
+        filename = 'my-file.jpg'
+        portal = self.layer['portal']
+        setRoles(portal, TEST_USER_ID, ('Manager',))
+        result = self._upload_file(filename)
+        self.assertEqual(result.get('success'), True)
+        self.assertFalse(result.get('error'))
+        self.assertEqual(result.get('name'), filename)
+        self.assertEqual(result.get('title'), 'my file')
+        self.assertTrue(filename in portal)
+        image = portal[filename]
+        self.assertEqual(image.Title(), 'my file')
+        self.assertEqual(result.get('uid'), image.UID())
+
+    def test_upload_file_unauthorized(self):
+        filename = 'my-file.jpg'
+        portal = self.layer['portal']
+        result = self._upload_file(filename)
+        self.assertEqual(result.get('error'), 'serverErrorNoPermission')
+        self.assertFalse(result.get('success'))
+        self.assertFalse(filename in portal)
+
+    def test_upload_file_twice_default(self):
+        filename = 'my-file.jpg'
+        portal = self.layer['portal']
+        setRoles(portal, TEST_USER_ID, ('Manager',))
+        # Upload twice.
+        result = self._upload_file(filename)
+        result = self._upload_file(filename, 'title two')
+        newid = 'my-file-1.jpg'
+        self.assertEqual(result.get('success'), True)
+        self.assertEqual(result.get('name'), newid)
+        self.assertEqual(result.get('title'), 'title two')
+        self.assertTrue(newid in portal)
+        image2 = portal[newid]
+        self.assertEqual(image2.Title(), 'title two')
+        self.assertEqual(result.get('uid'), image2.UID())
+
+    def test_upload_file_twice_override(self):
+        filename = 'my-file.jpg'
+        portal = self.layer['portal']
+        setRoles(portal, TEST_USER_ID, ('Manager',))
+        props = portal.portal_properties.quickupload_properties
+        props._updateProperty('object_unique_id', False)
+        props._updateProperty('object_override', True)
+        # We must explicitly commit, otherwise the change somehow gets lost
+        # between the two uploads, presumably due to the explicit commit in
+        # uploadcapable.py.
+        transaction.commit()
+        # Upload twice.
+        result = self._upload_file(filename)
+        result = self._upload_file(filename, 'title two')
+        newid = 'my-file-1.jpg'
+        self.assertEqual(result.get('success'), True)
+        self.assertEqual(result.get('name'), filename)
+        self.assertEqual(result.get('title'), 'title two')
+        self.assertFalse(newid in portal)
+        image2 = portal[filename]
+        self.assertEqual(image2.Title(), 'title two')
+        self.assertEqual(result.get('uid'), image2.UID())
+
+    def test_upload_file_twice_no_override(self):
+        filename = 'my-file.jpg'
+        portal = self.layer['portal']
+        setRoles(portal, TEST_USER_ID, ('Manager',))
+        props = portal.portal_properties.quickupload_properties
+        props._updateProperty('object_unique_id', False)
+        props._updateProperty('object_override', False)
+        # We must explicitly commit.
+        transaction.commit()
+        # Upload twice.
+        result = self._upload_file(filename)
+        result = self._upload_file(filename, 'title two')
+        newid = 'my-file-1.jpg'
+        self.assertEqual(result.get('error'), 'serverErrorAlreadyExists')
+        self.assertFalse(result.get('success'))
+        self.assertFalse(newid in portal)
+        self.assertTrue(filename in portal)
+        image = portal[filename]
+        self.assertEqual(image.Title(), 'my file')
+
+    def test_upload_file_id_as_title(self):
+        filename = 'my-file.jpg'
+        portal = self.layer['portal']
+        setRoles(portal, TEST_USER_ID, ('Manager',))
+        props = portal.portal_properties.quickupload_properties
+        props._updateProperty('id_as_title', True)
+        # We must explicitly commit.
+        transaction.commit()
+        result = self._upload_file(filename)
+        self.assertEqual(result.get('success'), True)
+        self.assertEqual(result.get('name'), filename)
+        self.assertEqual(result.get('title'), filename)
+        self.assertTrue(filename in portal)
+        image = portal[filename]
+        self.assertEqual(image.Title(), filename)
+
+    def test_upload_explicit_title_and_description(self):
+        filename = 'my-file.jpg'
+        portal = self.layer['portal']
+        setRoles(portal, TEST_USER_ID, ('Manager',))
+        # With id_as_title True, an explicit title still wins.
+        props = portal.portal_properties.quickupload_properties
+        props._updateProperty('id_as_title', True)
+        # We must explicitly commit.
+        transaction.commit()
+        title = 'Monty Python'
+        description = 'We are the knights who say ni.'
+        result = self._upload_file(filename, title, description)
+        self.assertEqual(result.get('success'), True)
+        self.assertEqual(result.get('name'), filename)
+        self.assertEqual(result.get('title'), title)
+        self.assertTrue(filename in portal)
+        image = portal[filename]
+        self.assertEqual(image.Title(), title)
+        self.assertEqual(image.Description(), description)

--- a/collective/quickupload/upgrades/configure.zcml
+++ b/collective/quickupload/upgrades/configure.zcml
@@ -51,4 +51,12 @@
       handler=".upgrades.v6_v7"
       profile="collective.quickupload:default" />
 
+  <genericsetup:upgradeStep
+      title="Add id_as_title property"
+      description=""
+      source="7"
+      destination="8"
+      handler=".upgrades.v7_v8"
+      profile="collective.quickupload:default" />
+
 </configure>

--- a/collective/quickupload/upgrades/upgrades.py
+++ b/collective/quickupload/upgrades/upgrades.py
@@ -19,7 +19,7 @@ def upgrade_resources(context):
 
 
 def v3_v4(context):
-    #Add property to quickupload property sheet
+    # Add property to quickupload property sheet
     ptool = getToolByName(context, 'portal_properties')
     qu_props = ptool.get('quickupload_properties')
     if not qu_props.hasProperty('use_flash_as_fallback'):
@@ -27,7 +27,7 @@ def v3_v4(context):
 
 
 def v4_v5(context):
-    #Add property to quickupload property sheet
+    # Add property to quickupload property sheet
     ptool = getToolByName(context, 'portal_properties')
     qu_props = ptool.get('quickupload_properties')
     if not qu_props.hasProperty('show_upload_action'):
@@ -35,17 +35,26 @@ def v4_v5(context):
     context.runImportStepFromProfile(
         'profile-collective.quickupload:default', 'actions')
 
+
 def v5_v6(context):
-    #Add property to quickupload property sheet
+    # Add property to quickupload property sheet
     ptool = getToolByName(context, 'portal_properties')
     qu_props = ptool.get('quickupload_properties')
     if not qu_props.hasProperty('object_override'):
         qu_props._setProperty('object_override', False, 'boolean')
 
+
 def v6_v7(context):
-    #Add property to quickupload property sheet
+    # Add property to quickupload property sheet
     ptool = getToolByName(context, 'portal_properties')
     qu_props = ptool.get('quickupload_properties')
     if not qu_props.hasProperty('object_unique_id'):
         qu_props._setProperty('object_unique_id', False, 'boolean')
 
+
+def v7_v8(context):
+    # Add property to quickupload property sheet
+    ptool = getToolByName(context, 'portal_properties')
+    qu_props = ptool.get('quickupload_properties')
+    if not qu_props.hasProperty('id_as_title'):
+        qu_props._setProperty('id_as_title', False, 'boolean')


### PR DESCRIPTION
A client wants to use the exact id as the title of uploaded files, so for example `my-file.jpg` instead of `my file`. When you upload an image in standard Plone 4.3 this is actually the default.  quickupload does it differently, prettifying the title.  `uploadcapable.py` has a remark "consolidation because it's different upon Plone versions" which is probably the reason why it differs.

An option would be to override `QuickUploadCapableFileFactory` in client code and set the title there. But I think it makes sense to support this in the control panel. With the new option switched on, the exact id is used as titel, unless you specify a title explicitly.

Default is False, so no change compared to the last release. Upgrade step added.

Bonus: I added tests for the `quick_upload_file` view, including testing for this and related settings.