### PR TITLE
Abort the transaction when file-upload fails with an error

### DIFF
--- a/collective/quickupload/browser/quick_upload.py
+++ b/collective/quickupload/browser/quick_upload.py
@@ -791,7 +791,7 @@ class QuickUploadFile(QuickUploadAuthenticate):
     def _success_response(self, obj):
         return json.dumps({
             u'success': True,
-            u'uid': IUUID(obj) if HAS_UUID else obj.UDI(),
+            u'uid': IUUID(obj) if HAS_UUID else obj.UID(),
             u'name': obj.getId(),
             u'title': obj.pretty_title_or_id()
         })

--- a/collective/quickupload/browser/quick_upload.py
+++ b/collective/quickupload/browser/quick_upload.py
@@ -25,6 +25,7 @@ from collective.quickupload.interfaces import IQuickUploadFileFactory
 from collective.quickupload.interfaces import IQuickUploadFileUpdater
 from collective.quickupload.interfaces import IQuickUploadNotCapable
 from plone.i18n.normalizer.interfaces import IUserPreferredFileNameNormalizer
+import transaction
 from ZODB.POSException import ConflictError
 from zope.component import getUtility
 from zope.i18n import translate
@@ -784,6 +785,7 @@ class QuickUploadFile(QuickUploadAuthenticate):
         return self._success_response(obj)
 
     def _error_response(self, msg):
+        transaction.abort()
         return json.dumps({u'error': msg})
 
     def _success_response(self, obj):

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,10 +4,16 @@ Changelog
 1.8.3 (unreleased)
 ------------------
 
+- Always abort the transaction when the file-upload fails with an error.
+  This prevents constructing partial files when a file-factory or
+  a file-updater fails after creating the content object.
+  [deiferni]
+
 - Updated Dutch translations.
   [maurits]
+
 - Fixed a Bug with jQuery 1.9+ in quickuploadportlet.py which prevents portlet
-  to be renderd. Added a tyr catch clause. [loechel]
+  to be rendered. Added a try catch clause. [loechel]
 
 1.8.2 (2015-11-13)
 ------------------


### PR DESCRIPTION
With this PR we always abort the transaction when the file-upload fails with an error. 
This prevents constructing partial files when a file-factory or a file-updater fails after creating the content object.

Motivation: In one of our products we have a custom `IQuickUploadFileFactory` which performs additional tasks after creating the file. Sometimes these tasks throw an error. Without the changes in this PR this leaves behind objects that are only partially processed by our system.

I have added some more tests for `quick_upload_file`, especially for the possible errors, all returns with an error should now be covered. Also i have refactored the control-flow a tiny bit using early returns, this removes one level of indentation and should improve readability.
