### PR TITLE
Fix inconsistent default object_unique_id config.

### DIFF
--- a/collective/quickupload/profiles/default/propertiestool.xml
+++ b/collective/quickupload/profiles/default/propertiestool.xml
@@ -10,7 +10,7 @@
   <property name="fill_descriptions" type="boolean">False</property>
   <property name="size_limit" type="int">0</property>
   <property name="sim_upload_limit" type="int">2</property>
-  <property name="object_unique_id" type="boolean">True</property>
+  <property name="object_unique_id" type="boolean">False</property>
   <property name="object_override" type="boolean">True</property>
   <property name="id_as_title" type="boolean">False</property>
  </object>

--- a/collective/quickupload/profiles/default/propertiestool.xml
+++ b/collective/quickupload/profiles/default/propertiestool.xml
@@ -11,7 +11,7 @@
   <property name="size_limit" type="int">0</property>
   <property name="sim_upload_limit" type="int">2</property>
   <property name="object_unique_id" type="boolean">False</property>
-  <property name="object_override" type="boolean">True</property>
+  <property name="object_override" type="boolean">False</property>
   <property name="id_as_title" type="boolean">False</property>
  </object>
 </object>

--- a/collective/quickupload/tests/test_view.py
+++ b/collective/quickupload/tests/test_view.py
@@ -178,10 +178,14 @@ class TestCase(unittest.TestCase):
             result = self._upload_file(filename)
             self.assertEqual({u"error": u"It's stone dead"}, result)
 
-    def test_upload_file_twice_default(self):
+    def test_upload_file_twice_unique_id(self):
         filename = 'my-file.jpg'
         portal = self.layer['portal']
         setRoles(portal, TEST_USER_ID, ('Manager',))
+        props = portal.portal_properties.quickupload_properties
+        props._updateProperty('object_unique_id', True)
+        # We must explicitly commit.
+        transaction.commit()
         # Upload twice.
         result = self._upload_file(filename)
         result = self._upload_file(filename, 'title two')
@@ -199,7 +203,6 @@ class TestCase(unittest.TestCase):
         portal = self.layer['portal']
         setRoles(portal, TEST_USER_ID, ('Manager',))
         props = portal.portal_properties.quickupload_properties
-        props._updateProperty('object_unique_id', False)
         props._updateProperty('object_override', True)
         # We must explicitly commit, otherwise the change somehow gets lost
         # between the two uploads, presumably due to the explicit commit in
@@ -217,15 +220,10 @@ class TestCase(unittest.TestCase):
         self.assertEqual(image2.Title(), 'title two')
         self.assertEqual(result.get('uid'), image2.UID())
 
-    def test_upload_file_twice_no_override(self):
+    def test_upload_file_twice_default(self):
         filename = 'my-file.jpg'
         portal = self.layer['portal']
         setRoles(portal, TEST_USER_ID, ('Manager',))
-        props = portal.portal_properties.quickupload_properties
-        props._updateProperty('object_unique_id', False)
-        props._updateProperty('object_override', False)
-        # We must explicitly commit.
-        transaction.commit()
         # Upload twice.
         result = self._upload_file(filename)
         result = self._upload_file(filename, 'title two')

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,10 @@ Changelog
 1.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix inconsistent 'object_unique_id' default configuration value.
+  Also use 'False' as default value for a fresh installation to be consistent with
+  the upgrade step and the form default value.
+  [deiferni]
 
 
 1.9.0 (2016-11-10)


### PR DESCRIPTION
In https://github.com/collective/collective.quickupload/pull/50 we introduced a new feature that allows to choose a unique id. Unfortunately the default value in that PR is inconsistent.

The default for `object_unique_id` when installing via upgrade is `False`, also the form default value in the schema is `False`. However the value in `propertiestool.xml` for a fresh installation is `True`.

Since `False` occurs twice i'm assuming that when installing the product freshly the default should also be `False`.

**Update:** same issue for `object_override`.

@jone @elioschmutz i'd like your opinion on this one; can we safely change the default? Be aware that if we merge it like this the generic setup profiles of some of our products where this behavior is actually desired might need to be updated.