### PR TITLE
Fix umlauts in error messages.

### DIFF
--- a/collective/quickupload/browser/static/fileuploader.js
+++ b/collective/quickupload/browser/static/fileuploader.js
@@ -179,8 +179,8 @@ qq.FileUploader.prototype = {
             eclass = document.createAttribute("class");
             eclass.nodeValue = "server-error";
             diverror.setAttributeNode(eclass);
-            diverror.innerText = message;
-            diverror.textContent = message;
+            // Since "message" contains entities, so it should be treated as HTML.
+            diverror.innerHTML = message;
         }
     },
     _formatFileName: function(name){

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,8 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
+- Fix umlauts in error messages. [jone]
+
 - Drop support for Plone 4.1, because buildout does no longer support Python 2.6. [jone]
 
 


### PR DESCRIPTION
Umlauts in error messages, such as the German ones, were displayed as XML entity (e.g. `&#252;`), because the message was inserted into the DOM as text, but the umlaut was already escaped as entity.
Text containing XML entities must be treated as HTML.

Before:
<img width="858" alt="bildschirmfoto 2017-03-09 um 15 27 14" src="https://cloud.githubusercontent.com/assets/7469/23754349/ecc3817c-04dc-11e7-8668-3444f6d762c5.png">
After:
<img width="850" alt="bildschirmfoto 2017-03-09 um 15 27 28" src="https://cloud.githubusercontent.com/assets/7469/23754357/ef61f8d2-04dc-11e7-9e95-e53be3433473.png">

//cc @deiferni 