### PR TITLE
Allow custom error messages.

### DIFF
--- a/collective/quickupload/browser/static/fileuploader.js
+++ b/collective/quickupload/browser/static/fileuploader.js
@@ -166,7 +166,7 @@ qq.FileUploader.prototype = {
         return element;
     },
     _error: function(code, fileName, id){
-        var message = this._options.messages[code];
+        var message = this._options.messages[code] || code;
         message = message.replace('{file}', this._formatFileName(fileName));
         message = message.replace('{extensions}', this._options.allowedExtensions.join(', '));
         message = message.replace('{sizeLimit}', this._formatSize(this._options.sizeLimit));

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,8 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
+- Allow custom error messages. [jone]
+
 - Fix umlauts in error messages. [jone]
 
 - Drop support for Plone 4.1, because buildout does no longer support Python 2.6. [jone]


### PR DESCRIPTION
When an error occurs, the server sends an error code and the JavaScript has a list of translated error messages for each error code. When unkown error code is sent, previously it wasn't displayed anything.
By changing the behavior to displaying the error code as fallback it is possible to customize the server part and send a custom error message (as error code), which will be displayed directly.

//cc @deiferni