### PR TITLE
Decode entities in error messages used in `alert`.

### DIFF
--- a/collective/quickupload/browser/static/fileuploader.js
+++ b/collective/quickupload/browser/static/fileuploader.js
@@ -78,7 +78,11 @@ qq.FileUploader = function(o){
             emptyError: "{file} is empty, please select files again without it."
         },
         showMessage: function(message){
-            alert(message);
+            // "message" contains entities so we use a temporary div to decode the
+            // htmlentities.
+            var decoder = document.createElement('div');
+            decoder.innerHTML = message;
+            alert(decoder.childNodes[0].nodeValue);
         },
         debugMode: false
     };

--- a/collective/quickupload/tests/test_controlpanel.py
+++ b/collective/quickupload/tests/test_controlpanel.py
@@ -7,6 +7,7 @@ except ImportError:
     import unittest
 
 from zope.component import getMultiAdapter
+from Products.CMFPlone.utils import getFSVersionTuple
 
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import logout
@@ -27,8 +28,10 @@ class ControlPanelTest(unittest.TestCase):
     def test_installed(self):
         # entry is in the control panel
         installed = [a.getAction(self)['id'] for a in self.cp.listActions()]
-        self.failUnless('QuickUpload' in installed)
+        self.assertIn('QuickUpload', installed)
 
+    @unittest.skipIf(getFSVersionTuple() < (4, 3,),
+                     'uninstallation does not seem to work in plone 4.2.')
     def test_uninstalled(self):
         setup_tool = getattr(self.portal, 'portal_setup')
         setup_tool.runAllImportStepsFromProfile(
@@ -36,7 +39,7 @@ class ControlPanelTest(unittest.TestCase):
 
         # entry is removed from the control panel
         installed = [a.getAction(self)['id'] for a in self.cp.listActions()]
-        self.failUnless('QuickUpload' in installed)
+        self.assertNotIn('QuickUpload', installed)
 
     def test_view(self):
         view = getMultiAdapter((self.portal, self.portal.REQUEST),

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,8 @@ Changelog
 1.11.1 (unreleased)
 -------------------
 
+- Decode htmlentities in error messages used in alert(). [deiferni]
+
 - Extend the uninstall profile.
   [thet]
 


### PR DESCRIPTION
The translated message contains html entities. Thus we need to decode the message before we `alert` it.
Simplest way to do so seems to be to create a temporary html element, see https://stackoverflow.com/questions/14937169/html-entities-in-a-javascript-alert. This is a follow-up for https://github.com/collective/collective.quickupload/pull/61.

Before:

![51845986-006feb00-2319-11e9-8199-d21bddf9c0a7](https://user-images.githubusercontent.com/736583/52415994-d7a1df80-2ae8-11e9-8545-e3bb07de2a61.png)


After:
![screenshot 2019-02-07 at 14 51 54](https://user-images.githubusercontent.com/736583/52415953-be992e80-2ae8-11e9-91c1-2344990ec662.png)

Also fix the tests, as the uninstall test seems to have been incorrect for some time but started failing recently. I strongly suspect `'QuickUpload'` shouldn't be in the installed list after uninstalling. This only seems to work on plone 4.2, not sure what is up. The tests have been failing on master before this PR, so so it is not related to the changes introduced here.

Now at least the test for plone 4.3 is correct and passes. Also switched to `assertIn`/`notIn` methods instead of using the deprecated `…unless` aliases (https://docs.python.org/2/library/unittest.html#deprecated-aliases).